### PR TITLE
feat: home icons and amount wrap fix

### DIFF
--- a/components/dashboard/CommitmentsSummary.tsx
+++ b/components/dashboard/CommitmentsSummary.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { CaretRight } from '@phosphor-icons/react'
+import { CaretRight, CreditCard } from '@phosphor-icons/react'
 import { formatAmount, formatDate } from '@/lib/format'
 import type { CompromisosData } from '@/lib/analytics/computeCompromisos'
 
@@ -72,12 +72,15 @@ export function CommitmentsSummary({
         ) : (
           <>
             <div className="flex items-start justify-between gap-3">
-              <div>
-                <p className="type-body text-text-secondary">Comprometido en tarjetas</p>
-                <p className="mt-1 type-meta text-text-dim">{footerText}</p>
+              <div className="flex min-w-0 items-start gap-3">
+                <CreditCard size={24} weight="regular" className="mt-0.5 shrink-0 text-primary" />
+                <div className="min-w-0">
+                  <p className="type-body text-text-secondary">Comprometido en tarjetas</p>
+                  <p className="mt-1 type-meta text-text-dim">{footerText}</p>
+                </div>
               </div>
-              <div className="flex items-center gap-1.5">
-                <span className="type-body-lg tabular-nums text-text-primary">
+              <div className="flex shrink-0 items-center gap-1.5">
+                <span className="whitespace-nowrap type-body-lg tabular-nums text-text-primary">
                   {amountsVisible ? formatAmount(total, currency) : maskAmount(currency)}
                 </span>
                 <CaretRight size={13} weight="bold" className="mt-0.5 text-text-dim" />

--- a/components/dashboard/SaldoVivo.tsx
+++ b/components/dashboard/SaldoVivo.tsx
@@ -2,7 +2,7 @@
 
 import type { CSSProperties } from 'react'
 import { useState } from 'react'
-import { CaretRight, Eye, EyeSlash } from '@phosphor-icons/react'
+import { CaretRight, Eye, EyeSlash, Wallet } from '@phosphor-icons/react'
 import { formatAmount } from '@/lib/format'
 import { DisponibleRealSheet } from './DisponibleRealSheet'
 import type { DashboardData, HeroBalanceMode } from '@/types/database'
@@ -184,14 +184,17 @@ export function SaldoVivo({
         onClick={() => setSheetOpen(true)}
         className="mt-5 flex w-full items-start justify-between gap-3 border-t border-[color:var(--color-separator)] pt-4 text-left transition-opacity hover:opacity-90"
       >
-        <div>
-          <p className="type-body text-text-secondary">Disponible real</p>
-          <p className="mt-1 type-meta text-text-dim">
-            Ya descuenta deuda y consumos en tarjeta.
-          </p>
+        <div className="flex min-w-0 items-start gap-3">
+          <Wallet size={24} weight="regular" className="mt-0.5 shrink-0 text-primary" />
+          <div className="min-w-0">
+            <p className="type-body text-text-secondary">Disponible real</p>
+            <p className="mt-1 type-meta text-text-dim">
+              Ya descuenta deuda y consumos en tarjeta.
+            </p>
+          </div>
         </div>
-        <div className="flex items-center gap-1.5">
-          <span className="type-body-lg tabular-nums text-text-primary">
+        <div className="flex shrink-0 items-center gap-1.5">
+          <span className="whitespace-nowrap type-body-lg tabular-nums text-text-primary">
             {amountsVisible ? formatAmount(availableValue, displayCurrency) : maskAmount(displayCurrency)}
           </span>
           <CaretRight size={13} weight="bold" className="mt-0.5 text-text-dim" />


### PR DESCRIPTION
Agrega íconos Phosphor en los bloques del Home y corrige el wrapping del monto.

- Ícono `Wallet` en "Disponible real"
- Ícono `CreditCard` en "Comprometido en tarjetas"
- Fix wrapping: $ y monto siempre en la misma línea

Cierra #18

Generated with [Claude Code](https://claude.ai/code)