### PR TITLE
feat: Íconos circulares en filas financieras del Home

### DIFF
--- a/components/dashboard/CommitmentsSummary.tsx
+++ b/components/dashboard/CommitmentsSummary.tsx
@@ -71,9 +71,11 @@ export function CommitmentsSummary({
           </div>
         ) : (
           <>
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex min-w-0 items-start gap-3">
-                <CreditCard size={24} weight="regular" className="mt-0.5 shrink-0 text-primary" />
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-3">
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-primary/20 bg-primary/10">
+                  <CreditCard size={22} weight="regular" className="text-primary" />
+                </div>
                 <div className="min-w-0">
                   <p className="type-body text-text-secondary">Comprometido en tarjetas</p>
                   <p className="mt-1 type-meta text-text-dim">{footerText}</p>

--- a/components/dashboard/SaldoVivo.tsx
+++ b/components/dashboard/SaldoVivo.tsx
@@ -182,10 +182,12 @@ export function SaldoVivo({
       <button
         type="button"
         onClick={() => setSheetOpen(true)}
-        className="mt-5 flex w-full items-start justify-between gap-3 border-t border-[color:var(--color-separator)] pt-4 text-left transition-opacity hover:opacity-90"
+        className="mt-5 flex w-full items-center justify-between gap-3 border-t border-[color:var(--color-separator)] pt-4 text-left transition-opacity hover:opacity-90"
       >
-        <div className="flex min-w-0 items-start gap-3">
-          <Wallet size={24} weight="regular" className="mt-0.5 shrink-0 text-primary" />
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-primary/20 bg-primary/10">
+            <Wallet size={22} weight="regular" className="text-primary" />
+          </div>
           <div className="min-w-0">
             <p className="type-body text-text-secondary">Disponible real</p>
             <p className="mt-1 type-meta text-text-dim">


### PR DESCRIPTION
Agrega contenedor circular suave (44×44px) a los íconos Wallet y CreditCard en las filas "Disponible real" y "Comprometido en tarjetas", haciéndolos visualmente consistentes con los íconos de Últimos movimientos.

Resolves #20

Generated with [Claude Code](https://claude.ai/code)