### PR TITLE
Improve empty-state rendering for en curso cards in Compromisos

### DIFF
--- a/components/analytics/Compromisos.tsx
+++ b/components/analytics/Compromisos.tsx
@@ -81,6 +81,7 @@ function TarjetaRow({ t, currency, showLink = false }: {
 }) {
   const isPaid = t.cycleStatus === 'pagado'
   const isDebt = t.cycleStatus === 'cerrado' || t.cycleStatus === 'vencido'
+  const isEnCursoSinConsumos = t.cycleStatus === 'en_curso' && t.currentSpend === 0
   const displayAmount = isDebt ? t.debtTotal : isPaid ? (t.amountPaid ?? 0) : t.currentSpend
 
   return (
@@ -128,7 +129,7 @@ function TarjetaRow({ t, currency, showLink = false }: {
 
         {/* Amount */}
         <span className={`shrink-0 type-body font-bold tabular-nums ${isPaid ? 'text-text-tertiary' : 'text-text-primary'}`}>
-          {formatAmount(displayAmount, currency)}
+          {isEnCursoSinConsumos ? '—' : formatAmount(displayAmount, currency)}
         </span>
       </div>
 
@@ -149,6 +150,13 @@ function TarjetaRow({ t, currency, showLink = false }: {
           Ir a pagar
           <ArrowRight size={11} weight="bold" />
         </Link>
+      )}
+
+      {/* En curso sin actividad */}
+      {isEnCursoSinConsumos && (
+        <p className="mt-2 type-micro text-text-dim">
+          Sin consumos registrados en este ciclo
+        </p>
       )}
     </div>
   )
@@ -262,6 +270,7 @@ export function CompromisosCard({ data, currency, selectedMonth, onClick }: Card
             <div className="mt-3 space-y-1.5 border-t border-border-ocean pt-3">
               {tarjetas.slice(0, 3).map((t) => {
                 const isPaid = t.cycleStatus === 'pagado'
+                const isEnCursoSinConsumos = t.cycleStatus === 'en_curso' && t.currentSpend === 0
                 const amt = t.cycleStatus === 'pagado' ? (t.amountPaid ?? 0)
                   : t.cycleStatus === 'en_curso' ? t.currentSpend
                   : t.debtTotal
@@ -283,7 +292,7 @@ export function CompromisosCard({ data, currency, selectedMonth, onClick }: Card
                       </span>
                     </div>
                     <span className={`type-meta tabular-nums ${isPaid ? 'text-text-tertiary' : 'text-text-primary'}`}>
-                      {formatAmount(amt, currency)}
+                      {isEnCursoSinConsumos ? '—' : formatAmount(amt, currency)}
                     </span>
                   </div>
                 )


### PR DESCRIPTION
### Motivation
- Avoid showing a literal `$0` for cards in `en_curso` with no activity because it reads noisy and can be visually misleading. 

### Description
- Add an `isEnCursoSinConsumos` flag in `TarjetaRow` and the compact mini-list and use a `—` fallback instead of `formatAmount(...)` when the card is `en_curso` and `currentSpend === 0`.
- Add a contextual helper line `Sin consumos registrados en este ciclo` in the detailed card row to clarify the empty state.
- Preserve existing behavior for `cerrado`/`vencido`/`pagado` statuses and keep the rest of the UI unchanged.

### Testing
- Ran `npm run lint -- components/analytics/Compromisos.tsx` which completed without errors (repository has unrelated warnings). 
- Ran `npm test` (Vitest) and all automated tests passed (`4` test files, `22` tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eea08239dc832b9403b110adc07ed0)