### PR TITLE
feat: Redisenio Movimientos - hero pills, filtros rapidos y avanzados

### DIFF
--- a/components/movimientos/FiltroSheet.tsx
+++ b/components/movimientos/FiltroSheet.tsx
@@ -7,9 +7,10 @@ import type { Account, Card } from '@/types/database'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type TipoFilter    = 'gasto' | 'ingreso' | 'transferencia' | 'suscripcion'
-export type OrigenFilter  = 'percibido' | 'tarjeta' | 'pago_tarjeta'
-export type MonedaFilter  = 'ARS' | 'USD'
+export type TipoFilter   = 'gasto' | 'ingreso' | 'transferencia' | 'suscripcion'
+export type OrigenFilter = 'percibido' | 'tarjeta' | 'pago_tarjeta'
+export type MonedaFilter = 'ARS' | 'USD'
+export type FechaFilter  = 'este_mes' | 'ultimos_7' | 'personalizado'
 
 export interface ActiveFilters {
   tipos:      TipoFilter[]
@@ -19,10 +20,17 @@ export interface ActiveFilters {
   categorias: string[]
   monedas:    MonedaFilter[]
   quincena:   1 | 2 | null
+  // UI-ready; pendiente de wiring a API
+  fecha:    FechaFilter | null
+  montoMin: string
+  montoMax: string
+  ordenar:  string
 }
 
 export const EMPTY_FILTERS: ActiveFilters = {
-  tipos: [], origenes: [], cuentas: [], tarjetas: [], categorias: [], monedas: [], quincena: null,
+  tipos: [], origenes: [], cuentas: [], tarjetas: [], categorias: [],
+  monedas: [], quincena: null,
+  fecha: null, montoMin: '', montoMax: '', ordenar: 'recientes',
 }
 
 export function countFilters(f: ActiveFilters): number {
@@ -37,19 +45,31 @@ export function countFilters(f: ActiveFilters): number {
   )
 }
 
+/** Cuenta grupos activos en filtros avanzados (excluye tipos/origenes, que maneja el filtro rápido). */
+export function countAdvancedGroups(f: ActiveFilters): number {
+  let n = 0
+  if (f.fecha) n++
+  if (f.cuentas.length + f.tarjetas.length > 0) n++
+  if (f.categorias.length > 0) n++
+  if (f.monedas.length > 0) n++
+  if ((f.montoMin && f.montoMin.trim() !== '') || (f.montoMax && f.montoMax.trim() !== '')) n++
+  if (f.quincena) n++
+  return n
+}
+
 // ─── Options ──────────────────────────────────────────────────────────────────
 
-const TIPO_OPTIONS: { value: TipoFilter; label: string }[] = [
-  { value: 'gasto',         label: 'Gasto' },
-  { value: 'ingreso',       label: 'Ingreso' },
-  { value: 'transferencia', label: 'Transferencia' },
-  { value: 'suscripcion',   label: 'Suscripción' },
+const FECHA_OPTIONS: { value: FechaFilter; label: string }[] = [
+  { value: 'este_mes',    label: 'Este mes' },
+  { value: 'ultimos_7',   label: 'Últimos 7 días' },
+  { value: 'personalizado', label: 'Personalizado' },
 ]
 
-const ORIGEN_OPTIONS: { value: OrigenFilter; label: string }[] = [
-  { value: 'percibido',    label: 'Percibido' },
-  { value: 'tarjeta',      label: 'Tarjeta' },
-  { value: 'pago_tarjeta', label: 'Pago tarjeta' },
+const TIPO_MOV_OPTIONS: { label: string; tipo: TipoFilter | null; origen: OrigenFilter | null }[] = [
+  { label: 'Gastos',       tipo: 'gasto',   origen: null },
+  { label: 'Ingresos',     tipo: 'ingreso', origen: null },
+  { label: 'Tarjetas',     tipo: null,      origen: 'tarjeta' },
+  { label: 'Pago tarjeta', tipo: null,      origen: 'pago_tarjeta' },
 ]
 
 const MONEDA_OPTIONS: { value: MonedaFilter; label: string }[] = [
@@ -60,23 +80,14 @@ const MONEDA_OPTIONS: { value: MonedaFilter; label: string }[] = [
 // ─── Chip styles ──────────────────────────────────────────────────────────────
 
 const CHIP_DEFAULT =
-  'shrink-0 rounded-pill px-3.5 py-1.5 text-[12px] font-medium border transition-colors bg-white/60 border-bg-secondary text-text-secondary'
+  'shrink-0 rounded-pill px-3.5 py-1.5 text-[12px] font-medium border transition-colors bg-bg-primary border-[color:var(--color-border-strong)] text-text-secondary'
 const CHIP_SELECTED =
-  'shrink-0 rounded-pill px-3.5 py-1.5 text-[12px] font-semibold border-[1.5px] transition-colors bg-[rgba(33,120,168,0.10)] border-[rgba(33,120,168,0.35)] text-primary'
+  'shrink-0 rounded-pill px-3.5 py-1.5 text-[12px] font-semibold border-[1.5px] transition-colors bg-primary/10 border-primary/35 text-primary'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function toggle<T>(arr: T[], val: T): T[] {
   return arr.includes(val) ? arr.filter((x) => x !== val) : [...arr, val]
-}
-
-function origenVisible(tipos: TipoFilter[]): boolean {
-  return tipos.length === 0 || tipos.some((t) => t === 'gasto' || t === 'suscripcion')
-}
-
-/** Origen = solo "tarjeta" seleccionado → mostrar filtro de tarjetas */
-function isTarjetaMode(origenes: OrigenFilter[]): boolean {
-  return origenes.length === 1 && origenes[0] === 'tarjeta'
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -116,67 +127,60 @@ function SectionHeader({
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function FiltroSheet({ open, onClose, onApply, initial, accounts, cards, categories }: Props) {
-  const [f, setF]                       = useState<ActiveFilters>(initial)
-  const [cuentasOpen, setCuentasOpen]   = useState(false)
-  const [tarjetasOpen, setTarjetasOpen] = useState(false)
-  const [catsOpen, setCatsOpen]         = useState(false)
+  const [f, setF]                         = useState<ActiveFilters>(initial)
+  const [cuentaMedioOpen, setCuentaMedioOpen] = useState(false)
+  const [catsOpen, setCatsOpen]           = useState(false)
 
-  // Sync pending state each time the sheet opens; collapse secondary sections
   useEffect(() => {
     if (open) {
       setF(initial)
-      setCuentasOpen(false)
-      setTarjetasOpen(false)
+      setCuentaMedioOpen(false)
       setCatsOpen(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
 
-  const showOrigen   = origenVisible(f.tipos)
-  const tarjetaMode  = isTarjetaMode(f.origenes)
-  const total        = countFilters(f)
+  const total = countFilters(f)
+  const advancedGroupTotal = countAdvancedGroups(f)
 
-  const setTipos = (tipos: TipoFilter[]) =>
+  const toggleTipoMov = (tipo: TipoFilter | null, origen: OrigenFilter | null) => {
     setF((prev) => ({
       ...prev,
-      tipos,
-      origenes: origenVisible(tipos) ? prev.origenes : [],
-    }))
-
-  // Al cambiar origen: si se pasa a modo tarjeta limpia cuentas (y viceversa)
-  const setOrigenes = (newOrigenes: OrigenFilter[]) => {
-    const willBeTarjeta = isTarjetaMode(newOrigenes)
-    if (willBeTarjeta) setCuentasOpen(false)
-    else setTarjetasOpen(false)
-    setF((prev) => ({
-      ...prev,
-      origenes:  newOrigenes,
-      cuentas:   willBeTarjeta ? [] : prev.cuentas,
-      tarjetas:  willBeTarjeta ? prev.tarjetas : [],
+      tipos:    tipo   ? toggle(prev.tipos,   tipo)   : prev.tipos,
+      origenes: origen ? toggle(prev.origenes, origen) : prev.origenes,
     }))
   }
+
+  const isTipoMovActive = (tipo: TipoFilter | null, origen: OrigenFilter | null) => {
+    if (tipo)   return f.tipos.includes(tipo)
+    if (origen) return f.origenes.includes(origen)
+    return false
+  }
+
+  const cuentaMedioCount = f.cuentas.length + f.tarjetas.length
+  const hasCuentaMedio   = accounts.length > 0 || cards.length > 0
 
   return (
     <Modal open={open} onClose={onClose}>
       {/* Drag handle */}
-      <div className="absolute top-2.5 inset-x-0 flex justify-center pointer-events-none">
+      <div className="pointer-events-none absolute inset-x-0 top-2.5 flex justify-center">
         <div className="h-1 w-10 rounded-full bg-text-disabled" />
       </div>
 
       {/* Header */}
-      <div className="flex items-center justify-between mb-5 mt-2">
+      <div className="mb-5 mt-2 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <h2 className="text-[16px] font-bold text-text-primary">Filtrar</h2>
-          {total > 0 && (
+          <h2 className="text-[16px] font-bold text-text-primary">Filtros avanzados</h2>
+          {(total > 0 || advancedGroupTotal > 0) && (
             <span className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold text-white">
-              {total}
+              {advancedGroupTotal > 0 ? advancedGroupTotal : total}
             </span>
           )}
         </div>
         {total > 0 && (
           <button
             onClick={() => setF(EMPTY_FILTERS)}
-            className="text-[12px] font-medium text-text-tertiary hover:text-text-secondary transition-colors"
+            className="text-[12px] font-medium text-text-tertiary transition-colors hover:text-text-secondary"
           >
             Limpiar
           </button>
@@ -186,15 +190,17 @@ export function FiltroSheet({ open, onClose, onApply, initial, accounts, cards, 
       {/* Sections */}
       <div className="space-y-6 pb-20">
 
-        {/* 1. Tipo */}
+        {/* A. Fecha */}
         <div>
-          <p className="type-label text-text-tertiary mb-3">Tipo</p>
+          <p className="type-label mb-3 text-text-tertiary">Fecha</p>
           <div className="flex flex-wrap gap-2">
-            {TIPO_OPTIONS.map(({ value, label }) => (
+            {FECHA_OPTIONS.map(({ value, label }) => (
               <button
                 key={value}
-                onClick={() => setTipos(toggle(f.tipos, value))}
-                className={f.tipos.includes(value) ? CHIP_SELECTED : CHIP_DEFAULT}
+                onClick={() =>
+                  setF((prev) => ({ ...prev, fecha: prev.fecha === value ? null : value }))
+                }
+                className={f.fecha === value ? CHIP_SELECTED : CHIP_DEFAULT}
               >
                 {label}
               </button>
@@ -202,39 +208,34 @@ export function FiltroSheet({ open, onClose, onApply, initial, accounts, cards, 
           </div>
         </div>
 
-        {/* 2. Origen */}
-        {showOrigen && (
-          <div>
-            <p className="type-label text-text-tertiary mb-3">Origen</p>
-            <div className="flex flex-wrap gap-2">
-              {ORIGEN_OPTIONS.map(({ value, label }) => (
-                <button
-                  key={value}
-                  onClick={() => setOrigenes(toggle(f.origenes, value))}
-                  className={f.origenes.includes(value) ? CHIP_SELECTED : CHIP_DEFAULT}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* 3a. Tarjeta — visible solo cuando origen = "tarjeta" */}
-        {tarjetaMode && cards.length > 0 && (
+        {/* B. Cuenta / medio */}
+        {hasCuentaMedio && (
           <div>
             <SectionHeader
-              label="Tarjeta"
-              count={f.tarjetas.length}
-              isOpen={tarjetasOpen}
-              onToggle={() => setTarjetasOpen((o) => !o)}
+              label="Cuenta / medio"
+              count={cuentaMedioCount}
+              isOpen={cuentaMedioOpen}
+              onToggle={() => setCuentaMedioOpen((o) => !o)}
             />
-            {tarjetasOpen && (
-              <div className="flex flex-wrap gap-2 mt-3">
+            {cuentaMedioOpen && (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {accounts.map((acc) => (
+                  <button
+                    key={acc.id}
+                    onClick={() =>
+                      setF((prev) => ({ ...prev, cuentas: toggle(prev.cuentas, acc.id) }))
+                    }
+                    className={f.cuentas.includes(acc.id) ? CHIP_SELECTED : CHIP_DEFAULT}
+                  >
+                    {acc.name}
+                  </button>
+                ))}
                 {cards.map((card) => (
                   <button
                     key={card.id}
-                    onClick={() => setF((prev) => ({ ...prev, tarjetas: toggle(prev.tarjetas, card.id) }))}
+                    onClick={() =>
+                      setF((prev) => ({ ...prev, tarjetas: toggle(prev.tarjetas, card.id) }))
+                    }
                     className={f.tarjetas.includes(card.id) ? CHIP_SELECTED : CHIP_DEFAULT}
                   >
                     {card.name}
@@ -245,32 +246,7 @@ export function FiltroSheet({ open, onClose, onApply, initial, accounts, cards, 
           </div>
         )}
 
-        {/* 3b. Cuenta — visible cuando origen NO es solo "tarjeta" */}
-        {!tarjetaMode && accounts.length > 0 && (
-          <div>
-            <SectionHeader
-              label="Cuenta"
-              count={f.cuentas.length}
-              isOpen={cuentasOpen}
-              onToggle={() => setCuentasOpen((o) => !o)}
-            />
-            {cuentasOpen && (
-              <div className="flex flex-wrap gap-2 mt-3">
-                {accounts.map((acc) => (
-                  <button
-                    key={acc.id}
-                    onClick={() => setF((prev) => ({ ...prev, cuentas: toggle(prev.cuentas, acc.id) }))}
-                    className={f.cuentas.includes(acc.id) ? CHIP_SELECTED : CHIP_DEFAULT}
-                  >
-                    {acc.name}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* 4. Categoría */}
+        {/* C. Categoría */}
         {categories.length > 0 && (
           <div>
             <SectionHeader
@@ -280,11 +256,13 @@ export function FiltroSheet({ open, onClose, onApply, initial, accounts, cards, 
               onToggle={() => setCatsOpen((o) => !o)}
             />
             {catsOpen && (
-              <div className="flex flex-wrap gap-2 mt-3">
+              <div className="mt-3 flex flex-wrap gap-2">
                 {categories.map((cat) => (
                   <button
                     key={cat}
-                    onClick={() => setF((prev) => ({ ...prev, categorias: toggle(prev.categorias, cat) }))}
+                    onClick={() =>
+                      setF((prev) => ({ ...prev, categorias: toggle(prev.categorias, cat) }))
+                    }
                     className={f.categorias.includes(cat) ? CHIP_SELECTED : CHIP_DEFAULT}
                   >
                     {cat}
@@ -295,14 +273,61 @@ export function FiltroSheet({ open, onClose, onApply, initial, accounts, cards, 
           </div>
         )}
 
-        {/* 5. Moneda */}
+        {/* D. Monto */}
         <div>
-          <p className="type-label text-text-tertiary mb-3">Moneda</p>
+          <p className="type-label mb-3 text-text-tertiary">Monto</p>
+          <div className="flex gap-3">
+            <div className="flex-1">
+              <label className="mb-1.5 block text-[11px] text-text-tertiary">Mínimo</label>
+              <input
+                type="number"
+                inputMode="numeric"
+                placeholder="0"
+                value={f.montoMin}
+                onChange={(e) => setF((prev) => ({ ...prev, montoMin: e.target.value }))}
+                className="w-full rounded-input border border-[color:var(--color-border-strong)] bg-bg-primary px-3 py-2 text-[14px] text-text-primary placeholder:text-text-disabled focus:border-primary/50 focus:outline-none"
+              />
+            </div>
+            <div className="flex-1">
+              <label className="mb-1.5 block text-[11px] text-text-tertiary">Máximo</label>
+              <input
+                type="number"
+                inputMode="numeric"
+                placeholder="∞"
+                value={f.montoMax}
+                onChange={(e) => setF((prev) => ({ ...prev, montoMax: e.target.value }))}
+                className="w-full rounded-input border border-[color:var(--color-border-strong)] bg-bg-primary px-3 py-2 text-[14px] text-text-primary placeholder:text-text-disabled focus:border-primary/50 focus:outline-none"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* E. Tipo de movimiento */}
+        <div>
+          <p className="type-label mb-3 text-text-tertiary">Tipo de movimiento</p>
+          <div className="flex flex-wrap gap-2">
+            {TIPO_MOV_OPTIONS.map(({ label, tipo, origen }) => (
+              <button
+                key={label}
+                onClick={() => toggleTipoMov(tipo, origen)}
+                className={isTipoMovActive(tipo, origen) ? CHIP_SELECTED : CHIP_DEFAULT}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Moneda */}
+        <div>
+          <p className="type-label mb-3 text-text-tertiary">Moneda</p>
           <div className="flex gap-2">
             {MONEDA_OPTIONS.map(({ value, label }) => (
               <button
                 key={value}
-                onClick={() => setF((prev) => ({ ...prev, monedas: toggle(prev.monedas, value) }))}
+                onClick={() =>
+                  setF((prev) => ({ ...prev, monedas: toggle(prev.monedas, value) }))
+                }
                 className={f.monedas.includes(value) ? CHIP_SELECTED : CHIP_DEFAULT}
               >
                 {label}
@@ -311,13 +336,27 @@ export function FiltroSheet({ open, onClose, onApply, initial, accounts, cards, 
           </div>
         </div>
 
+        {/* F. Ordenar por */}
+        <div>
+          <p className="type-label mb-3 text-text-tertiary">Ordenar por</p>
+          <div className="flex gap-2">
+            <button className={CHIP_SELECTED}>Más recientes</button>
+          </div>
+        </div>
+
       </div>
 
       {/* Sticky footer */}
-      <div className="sticky bottom-0 -mx-6 -mb-6 bg-bg-secondary px-6 pb-6 pt-4">
+      <div className="sticky bottom-0 -mx-6 -mb-6 flex gap-3 bg-bg-secondary px-6 pb-6 pt-4">
+        <button
+          onClick={() => setF(EMPTY_FILTERS)}
+          className="rounded-button border border-[color:var(--color-border-strong)] px-4 py-3 text-[14px] font-medium text-text-secondary transition-colors hover:bg-bg-tertiary active:opacity-70"
+        >
+          Limpiar
+        </button>
         <button
           onClick={() => { onApply(f); onClose() }}
-          className="w-full rounded-button bg-primary py-3 text-[14px] font-semibold text-white transition-all duration-150 hover:brightness-110 active:scale-95"
+          className="flex-1 rounded-button bg-primary py-3 text-[14px] font-semibold text-white transition-all duration-150 hover:brightness-110 active:scale-95"
         >
           Aplicar filtros
         </button>

--- a/components/movimientos/MovimientosClient.tsx
+++ b/components/movimientos/MovimientosClient.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { CaretLeft, CaretRight, X } from '@phosphor-icons/react'
+import { CaretLeft, CaretRight, SlidersHorizontal, X } from '@phosphor-icons/react'
 import { addMonths, getCurrentMonth } from '@/lib/dates'
 import { formatAmount } from '@/lib/format'
 import { HomePlusButton } from '@/components/dashboard/HomePlusButton'
 import { StripOperativo } from './StripOperativo'
 import { MovimientosGroupedList } from './MovimientosGroupedList'
-import { FiltroSheet, EMPTY_FILTERS, countFilters } from './FiltroSheet'
+import { FiltroSheet, EMPTY_FILTERS, countFilters, countAdvancedGroups } from './FiltroSheet'
 import type { ActiveFilters, OrigenFilter } from './FiltroSheet'
 import type {
   Account,
@@ -44,17 +44,33 @@ function formatMonthLabel(ym: string): string {
   return raw.charAt(0).toUpperCase() + raw.slice(1)
 }
 
-const TIPO_LABELS: Record<string, string> = {
-  gasto: 'Gasto',
-  ingreso: 'Ingreso',
-  transferencia: 'Transferencia',
-  suscripcion: 'Suscripción',
+// ─── Quick filter ──────────────────────────────────────────────────────────────
+
+type QuickFilter = 'todos' | 'gastos' | 'ingresos' | 'tarjetas'
+
+const QUICK_FILTER_LABELS: Record<QuickFilter, string> = {
+  todos:    'Todos',
+  gastos:   'Gastos',
+  ingresos: 'Ingresos',
+  tarjetas: 'Tarjetas',
 }
 
+function deriveQuickFilter(f: ActiveFilters): QuickFilter {
+  const { tipos, origenes } = f
+  if (tipos.length === 1 && tipos[0] === 'gasto'   && origenes.length === 0) return 'gastos'
+  if (tipos.length === 1 && tipos[0] === 'ingreso'  && origenes.length === 0) return 'ingresos'
+  if (origenes.length === 1 && origenes[0] === 'tarjeta' && tipos.length === 0) return 'tarjetas'
+  if (tipos.length === 0 && origenes.length === 0) return 'todos'
+  return 'todos'
+}
+
+// ─── Filter summary ────────────────────────────────────────────────────────────
+
+const TIPO_LABELS: Record<string, string> = {
+  gasto: 'Gasto', ingreso: 'Ingreso', transferencia: 'Transferencia', suscripcion: 'Suscripción',
+}
 const ORIGEN_LABELS: Record<string, string> = {
-  percibido: 'Percibido',
-  tarjeta: 'Tarjeta',
-  pago_tarjeta: 'Pago tarjeta',
+  percibido: 'Percibido', tarjeta: 'Tarjeta', pago_tarjeta: 'Pago tarjeta',
 }
 
 function buildFilterSummary(f: ActiveFilters, accounts: Account[], cards: Card[]): string {
@@ -82,8 +98,14 @@ function buildFilterSummary(f: ActiveFilters, accounts: Account[], cards: Card[]
 
   f.monedas.forEach((m) => parts.push(m))
   if (f.quincena) parts.push(f.quincena === 1 ? '1ra quincena' : '2da quincena')
+  if (f.fecha === 'este_mes')    parts.push('Este mes')
+  if (f.fecha === 'ultimos_7')   parts.push('Últ. 7 días')
+  if (f.montoMin)                parts.push(`Mín $${f.montoMin}`)
+  if (f.montoMax)                parts.push(`Máx $${f.montoMax}`)
   return parts.join(' · ')
 }
+
+// ─── Props ─────────────────────────────────────────────────────────────────────
 
 interface Props {
   initialMonth: string
@@ -139,14 +161,14 @@ export function MovimientosClient({ initialMonth, initialData, initialCategoria,
 
       try {
         const params = new URLSearchParams({ month, page: String(pg) })
-        if (filters.tipos.length > 0) params.set('tipos', filters.tipos.join(','))
-        if (filters.origenes.length > 0) params.set('origenes', filters.origenes.join(','))
-        if (filters.tarjetas.length > 0) params.set('tarjetas', filters.tarjetas.join(','))
-        if (filters.cuentas.length > 0) params.set('cuentas', filters.cuentas.join(','))
-        if (filters.categorias.length > 0)
-          params.set('categorias', filters.categorias.join(','))
-        if (filters.monedas.length > 0) params.set('monedas', filters.monedas.join(','))
-        if (filters.quincena) params.set('quincena', String(filters.quincena))
+        if (filters.tipos.length > 0)      params.set('tipos', filters.tipos.join(','))
+        if (filters.origenes.length > 0)   params.set('origenes', filters.origenes.join(','))
+        if (filters.tarjetas.length > 0)   params.set('tarjetas', filters.tarjetas.join(','))
+        if (filters.cuentas.length > 0)    params.set('cuentas', filters.cuentas.join(','))
+        if (filters.categorias.length > 0) params.set('categorias', filters.categorias.join(','))
+        if (filters.monedas.length > 0)    params.set('monedas', filters.monedas.join(','))
+        if (filters.quincena)              params.set('quincena', String(filters.quincena))
+        // fecha / monto / ordenar: UI-only por ahora; pendiente de soporte en API
 
         const res = await fetch(`/api/movimientos?${params}`)
         if (!res.ok) throw new Error('fetch failed')
@@ -203,7 +225,18 @@ export function MovimientosClient({ initialMonth, initialData, initialCategoria,
     })
   }
 
-  const activeCount = countFilters(activeFilters)
+  const handleQuickFilter = (qf: QuickFilter) => {
+    setActiveFilters((prev) => ({
+      ...prev,
+      tipos:    qf === 'gastos' ? ['gasto'] : qf === 'ingresos' ? ['ingreso'] : [],
+      origenes: qf === 'tarjetas' ? ['tarjeta'] : [],
+    }))
+  }
+
+  const activeCount    = countFilters(activeFilters)
+  const advancedCount  = countAdvancedGroups(activeFilters)
+  const currentQuickFilter = deriveQuickFilter(activeFilters)
+
   const activeOrigen: OrigenFilter | null =
     activeFilters.origenes.length === 1 ? activeFilters.origenes[0] : null
 
@@ -213,6 +246,7 @@ export function MovimientosClient({ initialMonth, initialData, initialCategoria,
         className="mx-auto flex max-w-md flex-col gap-5 px-4 pt-safe"
         style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + 100px)' }}
       >
+        {/* Month nav */}
         <div className="flex items-center justify-between pt-5">
           <div className="flex items-center gap-1">
             <button
@@ -243,6 +277,7 @@ export function MovimientosClient({ initialMonth, initialData, initialCategoria,
           />
         </div>
 
+        {/* Hero: 3 pills paralelos */}
         <StripOperativo
           percibidos={stats.percibidos}
           tarjeta={stats.tarjeta}
@@ -252,6 +287,44 @@ export function MovimientosClient({ initialMonth, initialData, initialCategoria,
           onOrigenClick={handleOrigenClick}
         />
 
+        {/* Quick filter pills + sliders button */}
+        <div className="flex items-center gap-2 overflow-x-auto pb-0.5">
+          {(Object.keys(QUICK_FILTER_LABELS) as QuickFilter[]).map((qf) => (
+            <button
+              key={qf}
+              onClick={() => handleQuickFilter(qf)}
+              className={[
+                'shrink-0 rounded-pill px-3.5 py-1.5 text-[12px] font-medium border transition-colors',
+                currentQuickFilter === qf
+                  ? 'bg-primary/10 border-primary/35 text-primary font-semibold'
+                  : 'bg-bg-primary border-[color:var(--color-border-strong)] text-text-secondary',
+              ].join(' ')}
+            >
+              {QUICK_FILTER_LABELS[qf]}
+            </button>
+          ))}
+
+          {/* Filtros avanzados */}
+          <button
+            onClick={() => setFilterOpen(true)}
+            aria-label="Filtros avanzados"
+            className={[
+              'relative ml-auto shrink-0 flex h-8 w-8 items-center justify-center rounded-full border transition-colors',
+              advancedCount > 0
+                ? 'bg-primary/10 border-primary/35 text-primary'
+                : 'bg-bg-primary border-[color:var(--color-border-strong)] text-text-secondary',
+            ].join(' ')}
+          >
+            <SlidersHorizontal size={15} weight="bold" />
+            {advancedCount > 0 && (
+              <span className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-primary px-0.5 text-[9px] font-bold text-white">
+                {advancedCount}
+              </span>
+            )}
+          </button>
+        </div>
+
+        {/* Active filter summary chip */}
         {activeCount > 0 && (
           <div className="flex items-center justify-between py-0.5">
             <button
@@ -274,6 +347,7 @@ export function MovimientosClient({ initialMonth, initialData, initialCategoria,
           </div>
         )}
 
+        {/* Movement list */}
         {isLoading ? (
           <div className="space-y-3">
             {[...Array(5)].map((_, i) => (

--- a/components/movimientos/StripOperativo.tsx
+++ b/components/movimientos/StripOperativo.tsx
@@ -1,7 +1,56 @@
 'use client'
 
+import { Wallet, CreditCard, CheckCircle } from '@phosphor-icons/react'
 import { formatCompact } from '@/lib/format'
 import type { OrigenFilter } from './FiltroSheet'
+
+interface PillProps {
+  label: string
+  amount: string
+  helper: string
+  icon: React.ReactNode
+  iconBg: string
+  active: boolean
+  accentClass: string
+  accentBgClass: string
+  accentBorderClass: string
+  onClick: () => void
+}
+
+function MovementPill({
+  label,
+  amount,
+  helper,
+  icon,
+  iconBg,
+  active,
+  accentClass,
+  accentBgClass,
+  accentBorderClass,
+  onClick,
+}: PillProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        'flex flex-1 flex-col rounded-card p-3 text-left transition-colors active:opacity-70',
+        active
+          ? `border ${accentBorderClass} ${accentBgClass}`
+          : 'glass-1',
+      ].join(' ')}
+    >
+      <div className={`mb-2 flex h-6 w-6 items-center justify-center rounded-full ${iconBg}`}>
+        {icon}
+      </div>
+      <p className={`type-label ${active ? accentClass : 'text-text-tertiary'}`}>{label}</p>
+      <p className="mt-1.5 whitespace-nowrap text-[15px] font-bold tracking-[-0.02em] text-text-primary">
+        {amount}
+      </p>
+      <p className="mt-1.5 text-[10px] leading-tight text-text-tertiary">{helper}</p>
+    </button>
+  )
+}
 
 interface Props {
   percibidos: number
@@ -20,70 +69,44 @@ export function StripOperativo({
   activeOrigen,
   onOrigenClick,
 }: Props) {
-  const isActive = (o: OrigenFilter) => activeOrigen === o
-
-  const cardClass = (o: OrigenFilter) =>
-    [
-      'rounded-[18px] px-4 py-3 text-left transition-colors',
-      onOrigenClick ? 'cursor-pointer active:opacity-60' : '',
-      isActive(o) ? 'bg-primary/6' : '',
-    ]
-      .filter(Boolean)
-      .join(' ')
-
   return (
-    <div className="surface-module rounded-[22px] px-4 py-4">
-      <button
+    <div className="flex gap-2">
+      <MovementPill
+        label="PERCIBIDOS"
+        amount={percibidos > 0 ? formatCompact(percibidos, currency) : '-'}
+        helper="Dinero que salió de tu cuenta"
+        icon={<Wallet size={13} weight="duotone" className="text-warning" />}
+        iconBg="bg-warning/10"
+        active={activeOrigen === 'percibido'}
+        accentClass="text-warning"
+        accentBgClass="bg-warning/10"
+        accentBorderClass="border-warning/30"
         onClick={() => onOrigenClick?.('percibido')}
-        className={`w-full ${cardClass('percibido')}`}
-        type="button"
-      >
-        <p className={`type-label ${isActive('percibido') ? 'text-primary' : 'text-text-secondary'}`}>
-          Percibidos
-        </p>
-        <p className="mt-1 text-[28px] font-extrabold tracking-[-0.03em] text-warning">
-          {formatCompact(percibidos, currency)}
-        </p>
-        <p className="mt-1 text-[12px] text-text-secondary">
-          Dinero que salió de tu cuenta
-        </p>
-      </button>
-
-      <div className="my-3 h-px bg-[color:var(--color-separator)]" />
-
-      <div className="grid grid-cols-2 gap-3">
-        <button
-          onClick={() => onOrigenClick?.('tarjeta')}
-          className={cardClass('tarjeta')}
-          type="button"
-        >
-          <p className={`type-label ${isActive('tarjeta') ? 'text-primary' : 'text-text-secondary'}`}>
-            Tarjeta
-          </p>
-          <p className="mt-1 text-[18px] font-bold tracking-[-0.02em] text-text-primary">
-            {tarjeta > 0 ? formatCompact(tarjeta, currency) : '-'}
-          </p>
-          <p className="mt-1 text-[12px] text-text-dim">
-            Consumos del mes sin pagar
-          </p>
-        </button>
-
-        <button
-          onClick={() => onOrigenClick?.('pago_tarjeta')}
-          className={cardClass('pago_tarjeta')}
-          type="button"
-        >
-          <p className={`type-label ${isActive('pago_tarjeta') ? 'text-primary' : 'text-text-secondary'}`}>
-            Pago tarjeta
-          </p>
-          <p className="mt-1 text-[18px] font-bold tracking-[-0.02em] text-primary">
-            {pagoTarjeta > 0 ? formatCompact(pagoTarjeta, currency) : '-'}
-          </p>
-          <p className="mt-1 text-[12px] text-text-dim">
-            Pagos por consumos previos
-          </p>
-        </button>
-      </div>
+      />
+      <MovementPill
+        label="TARJETA"
+        amount={tarjeta > 0 ? formatCompact(tarjeta, currency) : '-'}
+        helper="Consumos del mes sin pagar"
+        icon={<CreditCard size={13} weight="duotone" className="text-primary" />}
+        iconBg="bg-primary/10"
+        active={activeOrigen === 'tarjeta'}
+        accentClass="text-primary"
+        accentBgClass="bg-primary/10"
+        accentBorderClass="border-primary/30"
+        onClick={() => onOrigenClick?.('tarjeta')}
+      />
+      <MovementPill
+        label="PAGO TARJETA"
+        amount={pagoTarjeta > 0 ? formatCompact(pagoTarjeta, currency) : '-'}
+        helper="Pagos por consumos previos"
+        icon={<CheckCircle size={13} weight="duotone" className="text-success" />}
+        iconBg="bg-success/10"
+        active={activeOrigen === 'pago_tarjeta'}
+        accentClass="text-success"
+        accentBgClass="bg-success/10"
+        accentBorderClass="border-success/30"
+        onClick={() => onOrigenClick?.('pago_tarjeta')}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Closes #23

## Cambios

- `StripOperativo`: reemplaza el hero card por 3 pills paralelos de igual jerarquía (Percibidos, Tarjeta, Pago Tarjeta) con íconos Phosphor y colores semánticos vía tokens.
- `MovimientosClient`: agrega pills de filtros rápidos (Todos/Gastos/Ingresos/Tarjetas) y botón sliders con badge de grupos activos.
- `FiltroSheet`: renombrado a "Filtros avanzados", nuevas secciones (Fecha, Monto, Ordenar por), chip styles usando tokens.

## Notas

Fecha/Monto/Ordenar son UI-only; requieren soporte en la API como siguiente paso.

Generated with [Claude Code](https://claude.ai/code)