### PR TITLE
fix(analytics): design fixes — toggle, hero, sparkline, pills, tags

### DIFF
--- a/components/analytics/AnalyticsClient.tsx
+++ b/components/analytics/AnalyticsClient.tsx
@@ -171,26 +171,24 @@ export function AnalyticsClient({
 
           {displayCategorias.length > 0 && (
             <section className="mt-6 px-5">
-              <div className={movers.featuredInsight ? '' : 'mb-3'}>
-                <h3 className="type-title text-text-primary whitespace-nowrap overflow-hidden text-ellipsis">
+              <div className="mb-3 flex items-center gap-2">
+                <h3 className="type-title text-text-primary">
                   Qué movió el mes
                 </h3>
                 {movers.featuredInsight ? (
-                  <p
+                  <span
+                    className="ml-auto flex-shrink-0"
                     style={{
-                      display: 'inline-block',
-                      marginTop: 6,
-                      marginBottom: 12,
-                      fontSize: 11,
-                      fontWeight: 500,
-                      color: '#7A3010',
-                      background: '#FAEEDA',
+                      fontSize: 10,
+                      fontWeight: 700,
+                      color: 'var(--color-warning)',
+                      background: 'var(--color-warning-soft)',
                       borderRadius: 20,
-                      padding: '5px 12px',
+                      padding: '3px 8px',
                     }}
                   >
                     {movers.featuredInsight.label}
-                  </p>
+                  </span>
                 ) : null}
               </div>
 

--- a/components/analytics/AnalyticsHero.tsx
+++ b/components/analytics/AnalyticsHero.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { TrendUp } from '@phosphor-icons/react'
 import type { AnalyticsHeroData } from '@/lib/analytics/analytics-overview'
 import { formatAmount } from '@/lib/format'
 
@@ -9,10 +8,13 @@ interface Props {
   currency: 'ARS' | 'USD'
 }
 
-function toneClass(tone: AnalyticsHeroData['visualTone']): string {
-  if (tone === 'warning') return 'text-warning'
-  if (tone === 'positive') return 'text-success'
-  return 'text-primary'
+function splitSubcopy(text: string): { label: string; delta: string | null } {
+  const parts = text.split(' ')
+  const last = parts[parts.length - 1]
+  if (/^[+\-−]?\d+%$/.test(last)) {
+    return { label: parts.slice(0, -1).join(' '), delta: last }
+  }
+  return { label: text, delta: null }
 }
 
 export function AnalyticsHero({ hero, currency }: Props) {
@@ -20,27 +22,45 @@ export function AnalyticsHero({ hero, currency }: Props) {
     <section className="px-[22px] py-[18px]">
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
-          <p className="text-[30px] font-extrabold leading-[1.06] tracking-[-0.03em] text-text-primary">
-            {hero.headline}
+          <p className="text-sm font-semibold text-text-secondary truncate">
+            {hero.headline.length > 28 ? `${hero.headline.slice(0, 28)}…` : hero.headline}
           </p>
           <p className="mt-4 type-hero tabular-nums text-text-primary">
             {formatAmount(hero.amount, currency)}
           </p>
-          {hero.subcopy ? (
-            <p className="mt-3 text-[13px] font-medium text-text-secondary">{hero.subcopy}</p>
-          ) : null}
+          {hero.subcopy ? (() => {
+            const { label, delta } = splitSubcopy(hero.subcopy)
+            return (
+              <p className="mt-3 text-[13px] text-text-secondary">
+                {label}
+                {delta && (
+                  <span
+                    className="ml-1"
+                    style={{ color: 'var(--color-success)', fontWeight: 700 }}
+                  >
+                    {delta}
+                  </span>
+                )}
+              </p>
+            )
+          })() : null}
           {hero.driver ? (
-            <div className="mt-4 inline-flex items-center gap-2 rounded-pill bg-black/[0.04] px-3 py-1.5 text-[12px] font-medium text-text-secondary">
-              <span className={`inline-flex ${toneClass(hero.visualTone)}`}>
-                <TrendUp size={14} weight="duotone" />
-              </span>
-              <span>{hero.driver.label}</span>
-            </div>
+            <p className="mt-3 text-[13px] text-text-secondary">
+              {hero.driver.label}
+            </p>
           ) : null}
         </div>
 
         <div className="shrink-0 self-end pb-1">
-          <svg width="68" height="46" viewBox="0 0 68 46" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <svg
+            width="68"
+            height="46"
+            viewBox="0 0 68 46"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            style={{ overflow: 'visible' }}
+          >
             <path
               d="M0,38 L11,24 L22,30 L33,14 L46,20 L57,34 L68,26 L68,46 L0,46 Z"
               fill="rgba(33,120,168,0.07)"

--- a/components/analytics/AnalyticsModeToggle.tsx
+++ b/components/analytics/AnalyticsModeToggle.tsx
@@ -35,15 +35,15 @@ export function AnalyticsModeToggle({ mode, onChange }: Props) {
             style={{
               flex: 1,
               fontSize: 12,
-              fontWeight: active ? 600 : 500,
+              fontWeight: active ? 600 : 400,
               padding: '6px 16px',
               borderRadius: 16,
               border: 'none',
               cursor: 'pointer',
               transition: 'all 0.15s ease',
-              color: active ? '#0D1829' : '#90A4B0',
-              background: active ? '#fff' : 'transparent',
-              boxShadow: active ? '0 1px 3px rgba(13,24,41,0.10)' : 'none',
+              color: active ? '#fff' : 'var(--color-text-secondary)',
+              background: active ? 'var(--color-primary)' : 'transparent',
+              boxShadow: 'none',
             }}
           >
             {option.label}

--- a/components/analytics/CategoriaRow.tsx
+++ b/components/analytics/CategoriaRow.tsx
@@ -6,9 +6,9 @@ import { CategoryIcon } from '@/components/ui/CategoryIcon'
 import type { CategoriaMetric } from '@/lib/analytics/computeMetrics'
 
 const TIPO_LABEL: Record<string, { text: string; color: string }> = {
-  need: { text: 'Necesidad', color: colors.success },
-  want: { text: 'Deseo', color: colors.warning },
-  mixed: { text: 'Mixto', color: colors.data },
+  need: { text: 'Necesidad', color: 'var(--color-data)' },
+  want: { text: 'Deseo', color: 'var(--color-warning)' },
+  mixed: { text: 'Mixto', color: 'var(--color-text-secondary)' },
 }
 
 function getCategoryNote(cat: CategoriaMetric, currency: 'ARS' | 'USD'): string {
@@ -74,7 +74,10 @@ export function CategoriaRow({ cat, currency, mode, onClick }: Props) {
             />
           </div>
           {tipoMeta && (
-            <span style={{ color: tipoMeta.color, fontSize: 11, fontWeight: 500 }}>
+            <span
+              className="flex-shrink-0"
+              style={{ color: tipoMeta.color, fontSize: 10, fontWeight: 700 }}
+            >
               {tipoMeta.text}
             </span>
           )}


### PR DESCRIPTION
Fixes puntuales de diseño en la sección Análisis según spec del issue #25.

**Cambios:**
- Toggle: thumb activo con color primario y texto blanco
- Hero: headline pequeño/secundario, delta en verde, sin pill en driver
- Sparkline: overflow visible para evitar recorte
- Pill "Qué movió el mes": misma fila que título, colores token
- Tags Necesidad/Mixto/Deseo: colores semánticos y tamaño correcto

Closes #25

Generated with [Claude Code](https://claude.ai/code)