### PR TITLE
fix: excluir Pago de Tarjetas del pill Percibidos en Movimientos

### DIFF
--- a/app/(dashboard)/movimientos/page.tsx
+++ b/app/(dashboard)/movimientos/page.tsx
@@ -93,7 +93,7 @@ export default async function MovimientosPage({
   >[]
   const statsCurrency: 'ARS' | 'USD' = 'ARS'
   const percibidos = statsExpenses
-    .filter((e) => (isPerceivedExpense(e) || isCardPayment(e)) && e.currency === statsCurrency)
+    .filter((e) => isPerceivedExpense(e) && e.currency === statsCurrency)
     .reduce((s, e) => s + e.amount, 0)
   const tarjeta = statsExpenses
     .filter((e) => isCreditAccruedExpense(e) && e.currency === statsCurrency)

--- a/app/api/movimientos/route.ts
+++ b/app/api/movimientos/route.ts
@@ -144,7 +144,7 @@ export async function GET(request: Request) {
     activeMonedas.length === 1 && activeMonedas[0] === 'USD' ? 'USD' : 'ARS'
 
   const percibidos = statsExpenses
-    .filter((e) => (isPerceivedExpense(e) || isCardPayment(e)) && e.currency === statsCurrency)
+    .filter((e) => isPerceivedExpense(e) && e.currency === statsCurrency)
     .reduce((sum, e) => sum + e.amount, 0)
 
   const tarjeta = statsExpenses

--- a/components/movimientos/StripOperativo.tsx
+++ b/components/movimientos/StripOperativo.tsx
@@ -58,7 +58,7 @@ export function StripOperativo({
       key: 'percibido',
       label: 'Percibidos',
       value: formatCompact(percibidos, currency),
-      description: 'Salio de tu cuenta',
+      description: 'Gasto directo del mes',
       icon: Wallet,
       valueClassName: 'type-amount-sm text-warning',
       iconClassName: 'text-warning',


### PR DESCRIPTION
Fixes #27

- Quita `isCardPayment(e)` del filtro percibidos en `page.tsx` y `route.ts`
- El pill Percibidos ahora muestra solo gasto directo (cash/débito/transferencia), alineado con `gastosPercibidos` en `dashboard-queries.ts`
- Subtitle cambiado de "Salio de tu cuenta" a "Gasto directo del mes"

Generated with [Claude Code](https://claude.ai/code)