### PR TITLE
Preload FX quote to avoid delayed “Disponible real” render

### DIFF
--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -4,6 +4,38 @@ import { DashboardShell } from '@/components/dashboard/DashboardShell'
 import { getCurrentMonth } from '@/lib/dates'
 import { readDashboardData } from '@/lib/server/dashboard-queries'
 
+type InitialQuote = {
+  compra: number
+  venta: number
+  fechaActualizacion: string
+  rate: number
+  effectiveDate: string
+  updatedAt: string
+  source: 'dolarapi'
+  kind: 'oficial'
+  stale: boolean
+}
+
+function normalizeQuote(raw: Partial<InitialQuote>): InitialQuote | null {
+  const venta = Number(raw.venta)
+  const compra = Number(raw.compra)
+  const fechaActualizacion = raw.fechaActualizacion
+  if (!Number.isFinite(venta) || venta <= 0 || !Number.isFinite(compra) || !fechaActualizacion) {
+    return null
+  }
+  return {
+    compra,
+    venta,
+    fechaActualizacion,
+    rate: venta,
+    effectiveDate: new Date(fechaActualizacion).toLocaleDateString('es-AR', { day: '2-digit', month: 'short' }),
+    updatedAt: new Date(fechaActualizacion).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' }),
+    source: 'dolarapi',
+    kind: 'oficial',
+    stale: false,
+  }
+}
+
 export default async function DashboardPage({
   searchParams,
 }: {
@@ -27,12 +59,19 @@ export default async function DashboardPage({
   const { month, currency: currencyParam } = await searchParams
   const selectedMonth = month ?? getCurrentMonth()
   const viewCurrency = (currencyParam === 'USD' ? 'USD' : 'ARS') as 'ARS' | 'USD'
-  const initialData = await readDashboardData({
-    supabase,
-    userId: user.id,
-    selectedMonth,
-    viewCurrency,
-  })
+  const [initialData, initialQuote] = await Promise.all([
+    readDashboardData({
+      supabase,
+      userId: user.id,
+      selectedMonth,
+      viewCurrency,
+    }),
+    fetch('https://dolarapi.com/v1/dolares/oficial', {
+      next: { revalidate: 300 },
+    })
+      .then(async (res) => (res.ok ? normalizeQuote((await res.json()) as Partial<InitialQuote>) : null))
+      .catch(() => null),
+  ])
 
   return (
     <DashboardShell
@@ -40,6 +79,7 @@ export default async function DashboardPage({
       viewCurrency={viewCurrency}
       userEmail={user.email ?? ''}
       initialData={initialData}
+      initialQuote={initialQuote}
     />
   )
 }

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -27,6 +27,7 @@ interface Props {
   viewCurrency: 'ARS' | 'USD'
   userEmail: string
   initialData: DashboardApiData
+  initialQuote: CotizacionApiData | null
 }
 
 type CotizacionApiData = {
@@ -72,6 +73,7 @@ export function DashboardShell({
   viewCurrency,
   userEmail,
   initialData,
+  initialQuote,
 }: Props) {
   const queryClient = useQueryClient()
   const [breakdownOpen, setBreakdownOpen] = useState(false)
@@ -137,6 +139,7 @@ export function DashboardShell({
       return res.json()
     },
     staleTime: 300_000,
+    initialData: initialQuote,
   })
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- El componente de Home tardaba en mostrar el bloque “Disponible real” porque la cotización USD/ARS se obtenía solo en el cliente y llegaba después de la hidratación, provocando un retardo visual; la idea es precargar la cotización en el render del servidor para que el hero renderice inmediatamente.

### Description
- Precargo la cotización en paralelo con los datos del dashboard en `app/(dashboard)/page.tsx` y la normalizo con una nueva función `normalizeQuote` para evitar propagar datos inválidos.
- Paso la cotización inicial como `initialQuote` a `DashboardShell` y seedéo la query `cotizacion-bna` de React Query usando `initialData: initialQuote` para que el valor esté disponible desde el primer paint (archivo modificado: `components/dashboard/DashboardShell.tsx`).
- Cambio la llamada de fetch para obtener la cotización directamente en el servidor (`https://dolarapi.com/v1/dolares/oficial`) y mantengo el comportamiento de refetch y `staleTime` en el cliente sin cambios.

### Testing
- Ejecuté `npm run lint` y finalizó correctamente (hay 10 warnings preexistentes no relacionados con este cambio).  
- Ejecuté `npx tsc --noEmit` y pasó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33b4c8f44832bb9890153d73e42fd)