### PR TITLE
Acotar query de `compromisoExpenses` en analytics para acelerar Home

### DIFF
--- a/app/api/analytics-data/route.ts
+++ b/app/api/analytics-data/route.ts
@@ -161,6 +161,8 @@ export async function GET(request: Request) {
       .select('*')
       .eq('user_id', user.id)
       .eq('currency', currency)
+      .gte('date', historyStartDate)
+      .lt('date', endOfMonth)
       .or('payment_method.eq.CREDIT,category.eq.Pago de Tarjetas'),
 
     supabase


### PR DESCRIPTION
### Motivation
- Al abrir el Home el bloque “Comprometido en tarjetas” hacía un scan de todo el historial de `expenses`, provocando ~2s extra; limitar el rango temporal reduce filas leídas y mejora el tiempo de respuesta.

### Description
- En `app/api/analytics-data/route.ts` se añadió el mismo límite de fechas usado por el historial a la consulta que llena `compromisoExpenses`, agregando `.gte('date', historyStartDate).lt('date', endOfMonth)` sin cambiar los filtros de `user_id`, `currency` ni la condición `payment_method.eq.CREDIT,category.eq.Pago de Tarjetas`.

### Testing
- Ejecutado `npm run lint` y pasó (quedaron solo warnings preexistentes en otros archivos).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33d55609c832ba2617f469f6e2c2b)