### PR TITLE
Corregir selección de ciclos duplicados en compromisos (Insights)

### DIFF
--- a/lib/analytics/computeCompromisos.ts
+++ b/lib/analytics/computeCompromisos.ts
@@ -342,12 +342,19 @@ export function computeCompromisos(
       continue
     }
 
-    const cycle = cardCycles.find(
+    const cycleCandidates = cardCycles.filter(
       (c) => c.card_id === card.id && c.due_date.startsWith(selectedMonth),
     )
 
     // No cycle recorded for this month — skip silently
-    if (!cycle) continue
+    if (cycleCandidates.length === 0) continue
+
+    // Defensive resolution for inconsistent data (multiple cycles due in same month).
+    // Prefer paid cycles so a paid resumen is still shown in Insights even if another
+    // duplicate/unpaid draft cycle exists with monto 0.
+    const cycle =
+      cycleCandidates.find((candidate) => candidate.status === 'paid') ??
+      cycleCandidates.sort((a, b) => b.due_date.localeCompare(a.due_date))[0]
 
     const statementAmount = computeStatementAmount(cycle, card, expenses, cardCycles)
     const amount = getRemainingCardCycleAmount(statementAmount, cycle.amount_paid)


### PR DESCRIPTION
### Motivation
- Se corrigió un desalineamiento entre la vista de tarjetas y los Insights donde resúmenes pagados (ej. marzo) no aparecían en Insights por datos inconsistentes en `card_cycles` (duplicados por tarjeta+mes). 
- El problema provenía de que la lógica histórica elegía un único ciclo con `find(...)` y podía tomar el ciclo incorrecto cuando había más de uno para el mismo mes.

### Description
- Cambiado en `lib/analytics/computeCompromisos.ts` la resolución de ciclos históricos para un mes concreto a recopilar todos los `cycleCandidates` y no usar `find(...)` directo. 
- Si hay múltiples candidatos ahora se prioriza un ciclo con `status === 'paid'` y, si no existe uno pagado, se toma el de `due_date` más reciente como fallback. 
- Esta selección defensiva evita que un ciclo borrador/sin monto opaque un ciclo pagado y mantiene la vista de Insights alineada con la UI de tarjetas.

### Testing
- Ejecuté `npm test -- --runInBand` y falló por un flag no soportado por Vitest (error de CLI), lo que indica un comando incorrecto, no un fallo de la lógica. 
- Ejecuté `npm test` y la suite completa pasó localmente con `5` archivos de test y `28` tests aprobados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a987d0d0832bb8c1f2d25b86eb3a)