### PR TITLE
feat(pwa): add share target intake flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ next-env.d.ts
 .claude/
 
 .vercel
+.env*.local

--- a/app/(dashboard)/tarjetas/[cardId]/CardDetailClient.tsx
+++ b/app/(dashboard)/tarjetas/[cardId]/CardDetailClient.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, CaretDown, CaretUp, CheckCircle, ClockCounterClockwise } from '@phosphor-icons/react'
 import { formatAmount, formatDate } from '@/lib/format'
 import type { EnrichedCycle } from '@/lib/card-summaries'
@@ -96,6 +97,7 @@ export function CardDetailClient({
   initialCurrency,
 }: Props) {
   const router = useRouter()
+  const queryClient = useQueryClient()
   const [currentCard, setCurrentCard] = useState<Card>(card)
   const [isDeleting, setIsDeleting] = useState(false)
   const [isDeletingConfirm, setIsDeletingConfirm] = useState(false)
@@ -229,6 +231,9 @@ export function CardDetailClient({
         throw new Error(data?.error ?? 'Error al revertir el pago.')
       }
       setRevertingKey(null)
+      queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+      queryClient.invalidateQueries({ queryKey: ['account-breakdown'] })
+      queryClient.invalidateQueries({ queryKey: ['analytics'] })
       router.refresh()
     } catch (error) {
       setRevertError(error instanceof Error ? error.message : 'Error al revertir el pago.')
@@ -396,7 +401,7 @@ export function CardDetailClient({
           />
         )}
 
-        {cycle.cycleStatus === 'pagado' && (
+        {(cycle.cycleStatus === 'pagado' || (cycle.amount_paid ?? 0) > 0) && (
           <>
             {revertingKey === actionKey ? (
               <div className="mx-3 mb-2.5 space-y-2 rounded-input bg-danger/10 px-3 py-2.5">

--- a/app/(dashboard)/tarjetas/[cardId]/PagarResumenModal.tsx
+++ b/app/(dashboard)/tarjetas/[cardId]/PagarResumenModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { Modal } from '@/components/ui/Modal'
 import { paymentMethodFromAccountType } from '@/lib/cardPaymentPrompt'
 import { formatAmount, todayAR } from '@/lib/format'
+import { CATEGORIES } from '@/lib/validation/schemas'
 import type { Account, Card, Currency } from '@/types/database'
 import type { CycleGroup } from './CardDetailClient'
 
@@ -35,6 +36,15 @@ function formatMoneyInput(n: number): string {
   if (n === 0) return ''
   return new Intl.NumberFormat('es-AR', { maximumFractionDigits: 0 }).format(n)
 }
+
+type Motivo = 'gasto_olvidado' | 'cargo_banco' | 'no_detallar'
+
+type AdjustmentDraft = {
+  motivo: Motivo
+  categoriaExtra: string
+}
+
+const ADJUSTABLE_CATEGORIES = CATEGORIES.filter((category) => category !== 'Pago de Tarjetas')
 
 interface Props {
   open: boolean
@@ -71,6 +81,14 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
   const [accountId, setAccountId] = useState(defaultAccountId)
   const [usdAccountId, setUsdAccountId] = useState(defaultAccountId)
   const [fecha, setFecha] = useState(todayAR())
+  const [arsAdjustment, setArsAdjustment] = useState<AdjustmentDraft>({
+    motivo: 'no_detallar',
+    categoriaExtra: 'Otros',
+  })
+  const [usdAdjustment, setUsdAdjustment] = useState<AdjustmentDraft>({
+    motivo: 'no_detallar',
+    categoriaExtra: 'Otros',
+  })
   const [availableBalance, setAvailableBalance] = useState<number | null>(null)
   const [arsAvailableBalance, setArsAvailableBalance] = useState<number | null>(null)
   const [usdAvailableBalance, setUsdAvailableBalance] = useState<number | null>(null)
@@ -86,6 +104,8 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
     setAccountId(defaultAccountId)
     setUsdAccountId(defaultAccountId)
     setFecha(todayAR())
+    setArsAdjustment({ motivo: 'no_detallar', categoriaExtra: 'Otros' })
+    setUsdAdjustment({ motivo: 'no_detallar', categoriaExtra: 'Otros' })
     setAvailableBalance(null)
     setArsAvailableBalance(null)
     setUsdAvailableBalance(null)
@@ -195,6 +215,11 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
   const totalUsdOut = usdBlock && usdPayMode === 'USD' && usdAmount > 0 ? usdAmount : 0
   const showTotal = fromCurrency === 'ARS' ? totalArsOut > 0 : totalUsdOut > 0
 
+  const arsAdjustmentAmount = arsBlock ? Math.max(Math.round((arsAmount - arsRemaining) * 100) / 100, 0) : 0
+  const usdAdjustmentAmount = usdBlock ? Math.max(Math.round((usdAmount - usdRemaining) * 100) / 100, 0) : 0
+  const hasArsAdjustment = arsAdjustmentAmount >= 0.01
+  const hasUsdAdjustment = usdAdjustmentAmount >= 0.01
+
   const needsRate = !!(usdBlock && usdAmount > 0 && usdPayMode === 'ARS')
   const hasAnyAmount = (arsBlock ? arsAmount > 0 : false) || (usdBlock ? usdAmount > 0 : false)
   const requestedAmount = fromCurrency === 'ARS' ? totalArsOut : totalUsdOut
@@ -212,6 +237,38 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
     (!requiresUsdAccount || !!usdAccountId) &&
     (isSplitMode ? !arsExceedsBalance && !usdExceedsBalance : !exceedsBalance)
 
+  const buildAdjustmentPayload = (draft: AdjustmentDraft, amount: number) => {
+    if (amount < 0.01 || draft.motivo === 'no_detallar') return undefined
+
+    return {
+      amount,
+      category: draft.motivo === 'cargo_banco' ? 'Cargos Bancarios' : draft.categoriaExtra,
+      description: draft.motivo === 'cargo_banco' ? 'Cargo bancario' : 'Gasto no registrado',
+      is_want: false,
+    }
+  }
+
+  const adjustmentSections = [
+    {
+      key: 'ars',
+      label: 'ARS',
+      currency: 'ARS' as const,
+      amount: arsAdjustmentAmount,
+      visible: hasArsAdjustment,
+      draft: arsAdjustment,
+      setDraft: setArsAdjustment,
+    },
+    {
+      key: 'usd',
+      label: 'USD',
+      currency: 'USD' as const,
+      amount: usdAdjustmentAmount,
+      visible: hasUsdAdjustment,
+      draft: usdAdjustment,
+      setDraft: setUsdAdjustment,
+    },
+  ].filter((section) => section.visible)
+
   const handleSubmit = async () => {
     if (!canSubmit) return
     setIsSaving(true)
@@ -227,11 +284,19 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
         amount: number
         cycle_id?: string
         cycle?: { period_month: string; closing_date: string; due_date: string }
+        adjustment?: {
+          amount: number
+          category: string
+          description: string
+          is_want: boolean
+        }
       }
       const paymentItems: PaymentItem[] = []
 
       if (arsBlock && arsAmount > 0) {
         const item: PaymentItem = { currency: 'ARS', amount: arsAmount }
+        const adjustment = buildAdjustmentPayload(arsAdjustment, arsAdjustmentAmount)
+        if (adjustment) item.adjustment = adjustment
         if (arsBlock.cycle.source === 'stored') {
           item.cycle_id = arsBlock.cycle.id
         } else {
@@ -246,6 +311,8 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
 
       if (usdBlock && usdAmount > 0) {
         const item: PaymentItem = { currency: 'USD', amount: usdAmount }
+        const adjustment = buildAdjustmentPayload(usdAdjustment, usdAdjustmentAmount)
+        if (adjustment) item.adjustment = adjustment
         if (usdBlock.cycle.source === 'stored') {
           item.cycle_id = usdBlock.cycle.id
         } else {
@@ -346,7 +413,22 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
 
               {/* USD row */}
               <div className={usdPayMode === 'ARS' ? 'border-b border-border-subtle' : ''}>
-                <div className="flex items-center gap-3 px-4 py-3.5">
+                <div className="flex justify-end px-4 pt-3">
+                  <div className="flex items-center rounded-full bg-bg-secondary p-0.5">
+                    {(['USD', 'ARS'] as const).map((mode) => (
+                      <button
+                        key={mode}
+                        onClick={() => setUsdPayMode(mode)}
+                        className={`rounded-full px-3 py-1 text-[11px] font-semibold transition-colors ${
+                          usdPayMode === mode ? 'bg-primary text-white' : 'text-text-tertiary'
+                        }`}
+                      >
+                        {mode}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div className="flex items-center gap-3 px-4 pb-3.5 pt-2">
                   <span className="w-8 shrink-0 text-xs font-semibold text-text-secondary">USD</span>
                   <input
                     type="text"
@@ -356,23 +438,9 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
                       const raw = fromAR(e.target.value)
                       setUsdAmount(raw === '' ? 0 : parseFloat(raw))
                     }}
-                    className="flex-1 border-0 bg-transparent text-right text-[20px] font-bold tabular-nums text-text-primary focus:outline-none"
+                    className="min-w-0 flex-1 border-0 bg-transparent text-right text-[20px] font-bold tabular-nums text-text-primary focus:outline-none"
                     placeholder="0"
                   />
-                  {/* Mode toggle */}
-                  <div className="flex shrink-0 items-center rounded-full bg-bg-secondary p-0.5">
-                    {(['USD', 'ARS'] as const).map((mode) => (
-                      <button
-                        key={mode}
-                        onClick={() => setUsdPayMode(mode)}
-                        className={`rounded-full px-2.5 py-0.5 text-[10px] font-semibold transition-colors ${
-                          usdPayMode === mode ? 'bg-primary text-white' : 'text-text-tertiary'
-                        }`}
-                      >
-                        {mode}
-                      </button>
-                    ))}
-                  </div>
                 </div>
                 {usdRemaining > 0 && (
                   <p className="pb-2.5 pr-4 text-right text-xs text-text-tertiary">
@@ -623,6 +691,61 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
               ? 'El pago supera el saldo de una de las cuentas seleccionadas.'
               : 'El pago supera el saldo de la cuenta seleccionada.'}
           </p>
+        )}
+
+        {adjustmentSections.length > 0 && (
+          <div className="space-y-3 rounded-[18px] bg-bg-secondary px-4 py-4">
+            {adjustmentSections.map((section) => (
+              <div key={section.key} className="space-y-3 first:mt-0">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-text-tertiary">
+                  {section.label}: pagas {formatAmount(section.amount, section.currency)} de más · ¿Por qué?
+                </p>
+
+                {(['gasto_olvidado', 'cargo_banco', 'no_detallar'] as Motivo[]).map((motivo) => (
+                  <button
+                    key={`${section.key}-${motivo}`}
+                    type="button"
+                    onClick={() => section.setDraft((current) => ({ ...current, motivo }))}
+                    className="flex w-full items-center gap-3 text-left"
+                  >
+                    <div
+                      className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
+                        section.draft.motivo === motivo ? 'border-primary bg-primary' : 'border-border-strong'
+                      }`}
+                    >
+                      {section.draft.motivo === motivo && <div className="h-1.5 w-1.5 rounded-full bg-white" />}
+                    </div>
+                    <span className="text-sm text-text-primary">
+                      {motivo === 'gasto_olvidado'
+                        ? 'Gasto olvidado'
+                        : motivo === 'cargo_banco'
+                          ? 'Cargo del banco'
+                          : 'No detallar'}
+                    </span>
+                  </button>
+                ))}
+
+                {section.draft.motivo === 'gasto_olvidado' && (
+                  <div className="mt-1 border-t border-border-subtle pt-3">
+                    <p className="mb-2 text-[11px] text-text-tertiary">Categoría del gasto olvidado</p>
+                    <select
+                      value={section.draft.categoriaExtra}
+                      onChange={(event) =>
+                        section.setDraft((current) => ({ ...current, categoriaExtra: event.target.value }))
+                      }
+                      className="w-full rounded-input border border-border-strong bg-bg-primary px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    >
+                      {ADJUSTABLE_CATEGORIES.map((category) => (
+                        <option key={`${section.key}-${category}`} value={category}>
+                          {category}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
         )}
 
         {error && <p className="rounded-[14px] bg-danger-soft px-4 py-3 text-sm text-danger">{error}</p>}

--- a/app/(dashboard)/tarjetas/[cardId]/PagarResumenModal.tsx
+++ b/app/(dashboard)/tarjetas/[cardId]/PagarResumenModal.tsx
@@ -62,14 +62,18 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
     : 0
 
   const defaultAccountId = card.account_id ?? (accounts[0]?.id ?? '')
+  const bothCurrencies = !!(arsBlock && usdBlock)
 
   const [arsAmount, setArsAmount] = useState(Math.round(arsRemaining))
   const [usdAmount, setUsdAmount] = useState(usdRemaining)
   const [usdPayMode, setUsdPayMode] = useState<'USD' | 'ARS'>('ARS')
   const [exchangeRateStr, setExchangeRateStr] = useState('')
   const [accountId, setAccountId] = useState(defaultAccountId)
+  const [usdAccountId, setUsdAccountId] = useState(defaultAccountId)
   const [fecha, setFecha] = useState(todayAR())
   const [availableBalance, setAvailableBalance] = useState<number | null>(null)
+  const [arsAvailableBalance, setArsAvailableBalance] = useState<number | null>(null)
+  const [usdAvailableBalance, setUsdAvailableBalance] = useState<number | null>(null)
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -80,8 +84,11 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
     setUsdPayMode('ARS')
     setExchangeRateStr('')
     setAccountId(defaultAccountId)
+    setUsdAccountId(defaultAccountId)
     setFecha(todayAR())
     setAvailableBalance(null)
+    setArsAvailableBalance(null)
+    setUsdAvailableBalance(null)
     setError(null)
   }, [cycleGroup.key]) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -108,11 +115,13 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
   const hasArsPortion = !!(arsBlock && arsAmount > 0)
   const hasUsdInArsPortion = !!(usdBlock && usdAmount > 0 && usdPayMode === 'ARS')
   const fromCurrency: Currency = hasArsPortion || hasUsdInArsPortion ? 'ARS' : 'USD'
+  const isSplitMode = bothCurrencies && usdPayMode === 'USD' && hasArsPortion && usdAmount > 0
+  const primaryAccountLabel = isSplitMode ? 'Cuenta ARS' : fromCurrency === 'USD' ? 'Cuenta USD' : 'Cuenta'
 
   useEffect(() => {
     let cancelled = false
 
-    if (!accountId) {
+    if (!accountId || isSplitMode) {
       setAvailableBalance(null)
       return
     }
@@ -131,7 +140,55 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
     return () => {
       cancelled = true
     }
-  }, [accountId, fromCurrency])
+  }, [accountId, fromCurrency, isSplitMode])
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!isSplitMode || !accountId || arsAmount <= 0) {
+      setArsAvailableBalance(null)
+      return
+    }
+
+    void fetch('/api/dashboard/account-breakdown?currency=ARS')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (cancelled) return
+        const match = data?.breakdown?.find?.((account: { id: string; saldo: number }) => account.id === accountId)
+        setArsAvailableBalance(typeof match?.saldo === 'number' ? match.saldo : null)
+      })
+      .catch(() => {
+        if (!cancelled) setArsAvailableBalance(null)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [accountId, arsAmount, isSplitMode])
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!isSplitMode || !usdAccountId || usdAmount <= 0) {
+      setUsdAvailableBalance(null)
+      return
+    }
+
+    void fetch('/api/dashboard/account-breakdown?currency=USD')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (cancelled) return
+        const match = data?.breakdown?.find?.((account: { id: string; saldo: number }) => account.id === usdAccountId)
+        setUsdAvailableBalance(typeof match?.saldo === 'number' ? match.saldo : null)
+      })
+      .catch(() => {
+        if (!cancelled) setUsdAvailableBalance(null)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [usdAccountId, usdAmount, isSplitMode])
 
   // Total that leaves the account
   const totalArsOut = (hasArsPortion ? arsAmount : 0) + usdInArs
@@ -142,8 +199,18 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
   const hasAnyAmount = (arsBlock ? arsAmount > 0 : false) || (usdBlock ? usdAmount > 0 : false)
   const requestedAmount = fromCurrency === 'ARS' ? totalArsOut : totalUsdOut
   const exceedsBalance = availableBalance != null && requestedAmount > availableBalance + 0.01
+  const arsExceedsBalance = arsAvailableBalance != null && arsAmount > arsAvailableBalance + 0.01
+  const usdExceedsBalance = usdAvailableBalance != null && usdAmount > usdAvailableBalance + 0.01
+  const requiresPrimaryAccount = isSplitMode ? hasArsPortion : hasAnyAmount
+  const requiresUsdAccount = isSplitMode && usdAmount > 0
   const canSubmit =
-    hasAnyAmount && !!accountId && !!fecha && (!needsRate || exchangeRateNum > 0) && !isSaving && !exceedsBalance
+    hasAnyAmount &&
+    !!fecha &&
+    (!needsRate || exchangeRateNum > 0) &&
+    !isSaving &&
+    (!requiresPrimaryAccount || !!accountId) &&
+    (!requiresUsdAccount || !!usdAccountId) &&
+    (isSplitMode ? !arsExceedsBalance && !usdExceedsBalance : !exceedsBalance)
 
   const handleSubmit = async () => {
     if (!canSubmit) return
@@ -201,6 +268,10 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
         from_currency: fromCurrency,
       }
 
+      if (isSplitMode && usdAmount > 0) {
+        body.account_id_usd = usdAccountId
+      }
+
       if (needsRate && exchangeRateNum > 0) {
         body.exchange_rate = exchangeRateNum
       }
@@ -223,8 +294,6 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
       setIsSaving(false)
     }
   }
-
-  const bothCurrencies = !!(arsBlock && usdBlock)
 
   return (
     <Modal open={open} onClose={onClose}>
@@ -431,24 +500,46 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
         {/* ── Cuenta & Fecha ── */}
         <div className="overflow-hidden rounded-[18px] bg-bg-tertiary">
           {accounts.length > 0 && (
-            <div className="border-b border-border-subtle px-4 py-3.5">
-              <p className="mb-2 text-xs text-text-secondary">Cuenta</p>
-              <div className="flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-                {accounts.map((account) => (
-                  <button
-                    key={account.id}
-                    onClick={() => setAccountId(account.id)}
-                    className={`flex shrink-0 items-center rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
-                      accountId === account.id
-                        ? 'border-primary bg-primary/15 text-primary'
-                        : 'border-border-ocean bg-primary/[0.03] text-text-tertiary'
-                    }`}
-                  >
-                    {account.name}
-                  </button>
-                ))}
+            <>
+              <div className="border-b border-border-subtle px-4 py-3.5">
+                <p className="mb-2 text-xs text-text-secondary">{primaryAccountLabel}</p>
+                <div className="flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                  {accounts.map((account) => (
+                    <button
+                      key={account.id}
+                      onClick={() => setAccountId(account.id)}
+                      className={`flex shrink-0 items-center rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+                        accountId === account.id
+                          ? 'border-primary bg-primary/15 text-primary'
+                          : 'border-border-ocean bg-primary/[0.03] text-text-tertiary'
+                      }`}
+                    >
+                      {account.name}
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
+              {isSplitMode && (
+                <div className="border-b border-border-subtle px-4 py-3.5">
+                  <p className="mb-2 text-xs text-text-secondary">Cuenta USD</p>
+                  <div className="flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                    {accounts.map((account) => (
+                      <button
+                        key={`usd-${account.id}`}
+                        onClick={() => setUsdAccountId(account.id)}
+                        className={`flex shrink-0 items-center rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+                          usdAccountId === account.id
+                            ? 'border-primary bg-primary/15 text-primary'
+                            : 'border-border-ocean bg-primary/[0.03] text-text-tertiary'
+                        }`}
+                      >
+                        {account.name}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
           )}
           <div className="flex items-center justify-between px-4 py-3.5">
             <span className="text-sm text-text-secondary">Fecha</span>
@@ -462,32 +553,75 @@ export function PagarResumenModal({ open, onClose, onSuccess, cycleGroup, card, 
         </div>
 
         {/* ── Summary hints (plain text, no extra cards) ── */}
-        {(showTotal || availableBalance != null) && (
+        {isSplitMode ? (
           <div className="space-y-1 px-1">
-            {showTotal && (
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-text-tertiary">Total que sale de tu cuenta</span>
-                <span className="text-xs font-bold tabular-nums text-text-primary">
-                  {fromCurrency === 'ARS'
-                    ? formatAmount(totalArsOut, 'ARS')
-                    : formatAmount(totalUsdOut, 'USD')}
-                </span>
-              </div>
+            {hasArsPortion && (
+              <>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-text-tertiary">Sale de cuenta ARS</span>
+                  <span className="text-xs font-bold tabular-nums text-text-primary">
+                    {formatAmount(arsAmount, 'ARS')}
+                  </span>
+                </div>
+                {arsAvailableBalance != null && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-text-tertiary">Disponible ARS</span>
+                    <span className={`text-xs font-semibold tabular-nums ${arsExceedsBalance ? 'text-danger' : 'text-text-secondary'}`}>
+                      {formatAmount(arsAvailableBalance, 'ARS')}
+                    </span>
+                  </div>
+                )}
+              </>
             )}
-            {availableBalance != null && (
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-text-tertiary">Disponible hoy</span>
-                <span className={`text-xs font-semibold tabular-nums ${exceedsBalance ? 'text-danger' : 'text-text-secondary'}`}>
-                  {formatAmount(availableBalance, fromCurrency)}
-                </span>
-              </div>
+            {usdAmount > 0 && (
+              <>
+                <div className="flex items-center justify-between pt-1">
+                  <span className="text-xs text-text-tertiary">Sale de cuenta USD</span>
+                  <span className="text-xs font-bold tabular-nums text-text-primary">
+                    {formatAmount(usdAmount, 'USD')}
+                  </span>
+                </div>
+                {usdAvailableBalance != null && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-text-tertiary">Disponible USD</span>
+                    <span className={`text-xs font-semibold tabular-nums ${usdExceedsBalance ? 'text-danger' : 'text-text-secondary'}`}>
+                      {formatAmount(usdAvailableBalance, 'USD')}
+                    </span>
+                  </div>
+                )}
+              </>
             )}
           </div>
+        ) : (
+          (showTotal || availableBalance != null) && (
+            <div className="space-y-1 px-1">
+              {showTotal && (
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-text-tertiary">Total que sale de tu cuenta</span>
+                  <span className="text-xs font-bold tabular-nums text-text-primary">
+                    {fromCurrency === 'ARS'
+                      ? formatAmount(totalArsOut, 'ARS')
+                      : formatAmount(totalUsdOut, 'USD')}
+                  </span>
+                </div>
+              )}
+              {availableBalance != null && (
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-text-tertiary">Disponible hoy</span>
+                  <span className={`text-xs font-semibold tabular-nums ${exceedsBalance ? 'text-danger' : 'text-text-secondary'}`}>
+                    {formatAmount(availableBalance, fromCurrency)}
+                  </span>
+                </div>
+              )}
+            </div>
+          )
         )}
 
-        {exceedsBalance && (
-          <p className="text-xs text-danger px-1">
-            El pago supera el saldo de la cuenta seleccionada.
+        {(isSplitMode ? arsExceedsBalance || usdExceedsBalance : exceedsBalance) && (
+          <p className="px-1 text-xs text-danger">
+            {isSplitMode
+              ? 'El pago supera el saldo de una de las cuentas seleccionadas.'
+              : 'El pago supera el saldo de la cuenta seleccionada.'}
           </p>
         )}
 

--- a/app/api/card-cycles/[id]/revert/route.ts
+++ b/app/api/card-cycles/[id]/revert/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getEffectiveCardCycleState, isMissingCardCycleAmountsTableError } from '@/lib/card-cycle-amounts'
+import { getAccumulatedPaidAmount } from '@/lib/card-cycle-payments'
 import { createClient } from '@/lib/supabase/server'
 
 function isMissingCardPaymentAllocationsTableError(message: string | undefined): boolean {
@@ -65,16 +66,16 @@ export async function POST(
     cycleAmountsData ? new Map([[id, { [currency]: cycleAmountsData }]]) : undefined,
   )
 
-  if (state.status !== 'paid') return NextResponse.json({ error: 'Cycle is not paid' }, { status: 400 })
-  if (!state.paid_at || state.amount_paid == null) {
+  if (getAccumulatedPaidAmount(state.amount_paid) <= 0) {
     return NextResponse.json({ error: 'Cycle payment data is incomplete' }, { status: 400 })
   }
 
   const { data: allocations, error: allocationsError } = await supabase
     .from('card_payment_allocations')
-    .select('id, expense_id, amount_applied')
+    .select('id, expense_id, amount_applied, currency')
     .eq('user_id', user.id)
     .eq('card_cycle_id', id)
+    .eq('currency', currency)
 
   if (allocationsError && !isMissingCardPaymentAllocationsTableError(allocationsError.message)) {
     return NextResponse.json({ error: allocationsError.message }, { status: 500 })
@@ -143,6 +144,11 @@ export async function POST(
 
     await deleteAdjustmentExpenses(supabase, user.id, cycle.closing_date, currency)
 
+    const nextAmountPaid = Math.max(
+      0,
+      getAccumulatedPaidAmount(state.amount_paid) - getAccumulatedPaidAmount(matchingAllocation.amount_applied),
+    )
+
     const { error: resetError } = await supabase
       .from('card_cycle_amounts')
       .upsert({
@@ -151,12 +157,19 @@ export async function POST(
         currency,
         status: 'open',
         paid_at: null,
-        amount_paid: null,
+        amount_paid: nextAmountPaid > 0 ? nextAmountPaid : null,
         amount_draft: null,
       }, { onConflict: 'card_cycle_id,currency' })
 
     if (resetError) return NextResponse.json({ error: resetError.message }, { status: 500 })
     return NextResponse.json({ ok: true, mode: 'allocations' })
+  }
+
+  if (!state.paid_at || state.amount_paid == null) {
+    return NextResponse.json(
+      { error: 'No se puede revertir este pago porque no hay un pago cerrado compatible.' },
+      { status: 400 },
+    )
   }
 
   const paidDate = state.paid_at.substring(0, 10)

--- a/app/api/card-payments/route.ts
+++ b/app/api/card-payments/route.ts
@@ -43,6 +43,7 @@ type UnifiedBody = {
   card_id: string
   date: string
   account_id: string | null
+  account_id_usd?: string | null
   payment_method?: PaymentMethod
   description?: string
   payments: PaymentItem[]
@@ -105,6 +106,17 @@ type CycleUpdatePlan = {
   }
 }
 
+type PlannedItem = {
+  plans: CycleUpdatePlan[]
+  item: PaymentItem
+}
+
+type Leg = {
+  items: PaymentItem[]
+  accountId: string | null
+  legCurrency: 'ARS' | 'USD'
+}
+
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
 function isMissingCardPaymentAllocationsTableError(message: string | undefined): boolean {
@@ -113,6 +125,46 @@ function isMissingCardPaymentAllocationsTableError(message: string | undefined):
 
 function roundMoney(value: number): number {
   return Math.round((value + Number.EPSILON) * 100) / 100
+}
+
+function getRequestedAmountForLeg(params: {
+  leg: Leg
+  plannedItems: PlannedItem[]
+  exchangeRate?: number | null
+}): number {
+  const { leg, plannedItems, exchangeRate } = params
+
+  return roundMoney(
+    plannedItems.reduce((sum, planned) => {
+      const belongsToLeg = leg.items.some((item) => item === planned.item)
+      if (!belongsToLeg) return sum
+
+      const applied = roundMoney(planned.plans.reduce((subtotal, plan) => subtotal + plan.appliedAmount, 0))
+
+      if (planned.item.currency === leg.legCurrency) {
+        return sum + applied
+      }
+
+      if (planned.item.currency === 'USD' && leg.legCurrency === 'ARS' && exchangeRate) {
+        return sum + roundMoney(applied * exchangeRate)
+      }
+
+      return sum
+    }, 0),
+  )
+}
+
+function getCreatedExpenseIds(expenseIdByLegCurrency: Partial<Record<'ARS' | 'USD', string>>): string[] {
+  return Object.values(expenseIdByLegCurrency).filter((value): value is string => !!value)
+}
+
+function getAllocationExpenseCurrency(params: {
+  itemCurrency: 'ARS' | 'USD'
+  expenseIdByLegCurrency: Partial<Record<'ARS' | 'USD', string>>
+  fallbackCurrency: 'ARS' | 'USD'
+}): 'ARS' | 'USD' {
+  const { itemCurrency, expenseIdByLegCurrency, fallbackCurrency } = params
+  return expenseIdByLegCurrency[itemCurrency] ? itemCurrency : fallbackCurrency
 }
 
 function addOneDay(dateStr: string): string {
@@ -341,7 +393,7 @@ export async function POST(request: Request) {
     }
   }
 
-  const { card_id, account_id, from_currency, exchange_rate, payments, is_legacy_card_payment } = unifiedBody
+  const { card_id, account_id, account_id_usd, from_currency, exchange_rate, payments, is_legacy_card_payment } = unifiedBody
   const paymentMethod: PaymentMethod = unifiedBody.payment_method ?? 'DEBIT'
   const rawDate = typeof unifiedBody.date === 'string' ? unifiedBody.date : ''
   const paymentDate = rawDate.substring(0, 10)
@@ -446,7 +498,6 @@ export async function POST(request: Request) {
   const cycleAmountsMap = buildCardCycleAmountsMap(cycleAmountsData ?? [])
 
   // ── Build plans for each payment item ────────────────────────────────────
-  type PlannedItem = { plans: CycleUpdatePlan[]; item: PaymentItem }
   const allPlannedItems: PlannedItem[] = []
 
   try {
@@ -476,66 +527,91 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'No se pudo aplicar este pago a ningún resumen' }, { status: 400 })
   }
 
-  // ── Compute total amount in from_currency ─────────────────────────────────
-  let totalInFromCurrency = 0
-  for (const { plans, item } of allPlannedItems) {
-    const totalApplied = roundMoney(plans.reduce((sum, p) => sum + p.appliedAmount, 0))
-    if (item.currency === from_currency) {
-      totalInFromCurrency += totalApplied
-    } else if (item.currency === 'USD' && from_currency === 'ARS' && exchange_rate) {
-      totalInFromCurrency += roundMoney(totalApplied * exchange_rate)
-    }
-    // USD paid with USD (from_currency='USD'): totalApplied already in USD
-    // ARS paid with USD: not supported
-  }
-  totalInFromCurrency = roundMoney(totalInFromCurrency)
+  const arsItems = payments.filter((item) => item.currency === 'ARS' && roundMoney(item.amount ?? 0) > 0)
+  const usdItems = payments.filter((item) => item.currency === 'USD' && roundMoney(item.amount ?? 0) > 0)
+  const hasSplitLegs = !!account_id_usd && arsItems.length > 0 && usdItems.length > 0 && from_currency === 'ARS'
 
-  if (account_id) {
+  const legs: Leg[] = hasSplitLegs
+    ? [
+        { items: arsItems, accountId: account_id, legCurrency: 'ARS' },
+        { items: usdItems, accountId: account_id_usd, legCurrency: 'USD' },
+      ]
+    : [{ items: payments, accountId: account_id, legCurrency: from_currency }]
+
+  for (const leg of legs) {
+    if (!leg.accountId) continue
+
+    const requestedAmount = getRequestedAmountForLeg({
+      leg,
+      plannedItems: allPlannedItems,
+      exchangeRate: exchange_rate,
+    })
+
+    if (requestedAmount <= 0) continue
+
     const availableBalance = await getCurrentAccountBalance({
       supabase,
       userId: user.id,
-      accountId: account_id,
-      currency: from_currency,
+      accountId: leg.accountId,
+      currency: leg.legCurrency,
     })
 
-    if (availableBalance != null && !hasSufficientFunds(availableBalance, totalInFromCurrency)) {
+    if (availableBalance != null && !hasSufficientFunds(availableBalance, requestedAmount)) {
       return NextResponse.json(
         {
-          error: `No alcanza el saldo de la cuenta seleccionada. Disponible hoy: ${formatAmount(availableBalance, from_currency)}.`,
+          error: `No alcanza el saldo de la cuenta seleccionada. Disponible hoy: ${formatAmount(availableBalance, leg.legCurrency)}.`,
           code: 'INSUFFICIENT_FUNDS',
           availableBalance,
-          requestedAmount: totalInFromCurrency,
-          currency: from_currency,
+          requestedAmount,
+          currency: leg.legCurrency,
         },
         { status: 400 },
       )
     }
   }
 
-  // ── Create single payment expense ─────────────────────────────────────────
-  const { data: paymentExpense, error: paymentExpenseError } = await supabase
-    .from('expenses')
-    .insert({
-      user_id: user.id,
-      amount: totalInFromCurrency,
-      currency: from_currency,
-      category: 'Pago de Tarjetas',
-      description: unifiedBody.description ?? `Pago ${card.name}`,
-      payment_method: paymentMethod,
-      card_id: card.id,
-      account_id,
-      date: rawDate,
-      is_want: null,
-      is_legacy_card_payment: false,
-    })
-    .select('id')
-    .single()
+  // ── Create one payment expense per leg ────────────────────────────────────
+  const expenseIdByLegCurrency: Partial<Record<'ARS' | 'USD', string>> = {}
 
-  if (paymentExpenseError || !paymentExpense) {
-    return NextResponse.json(
-      { error: paymentExpenseError?.message ?? 'No se pudo registrar el pago' },
-      { status: 500 },
-    )
+  for (const leg of legs) {
+    const legTotal = getRequestedAmountForLeg({
+      leg,
+      plannedItems: allPlannedItems,
+      exchangeRate: exchange_rate,
+    })
+
+    if (legTotal <= 0) continue
+
+    const { data: paymentExpense, error: paymentExpenseError } = await supabase
+      .from('expenses')
+      .insert({
+        user_id: user.id,
+        amount: legTotal,
+        currency: leg.legCurrency,
+        category: 'Pago de Tarjetas',
+        description: unifiedBody.description ?? `Pago ${card.name}`,
+        payment_method: paymentMethod,
+        card_id: card.id,
+        account_id: leg.accountId,
+        date: rawDate,
+        is_want: null,
+        is_legacy_card_payment: false,
+      })
+      .select('id')
+      .single()
+
+    if (paymentExpenseError || !paymentExpense) {
+      const createdExpenseIds = getCreatedExpenseIds(expenseIdByLegCurrency)
+      if (createdExpenseIds.length > 0) {
+        await supabase.from('expenses').delete().eq('user_id', user.id).in('id', createdExpenseIds)
+      }
+      return NextResponse.json(
+        { error: paymentExpenseError?.message ?? 'No se pudo registrar el pago' },
+        { status: 500 },
+      )
+    }
+
+    expenseIdByLegCurrency[leg.legCurrency] = paymentExpense.id
   }
 
   // ── Create adjustment expenses (per payment item, if applicable) ──────────
@@ -543,7 +619,6 @@ export async function POST(request: Request) {
 
   for (const { plans, item } of allPlannedItems) {
     if (!item.adjustment || item.adjustment.amount <= 0) continue
-    // Only apply adjustment when there's an explicit cycle target
     const hasExplicitCycle = !!(item.cycle_id || item.cycle?.period_month)
     if (!hasExplicitCycle) continue
 
@@ -568,8 +643,10 @@ export async function POST(request: Request) {
       .single()
 
     if (adjustmentError || !adjustmentExpense) {
-      // Rollback payment expense
-      await supabase.from('expenses').delete().eq('id', paymentExpense.id).eq('user_id', user.id)
+      const createdExpenseIds = getCreatedExpenseIds(expenseIdByLegCurrency)
+      if (createdExpenseIds.length > 0) {
+        await supabase.from('expenses').delete().eq('user_id', user.id).in('id', createdExpenseIds)
+      }
       for (const adjId of adjustmentExpenseIds) {
         await supabase.from('expenses').delete().eq('id', adjId).eq('user_id', user.id)
       }
@@ -583,23 +660,38 @@ export async function POST(request: Request) {
   }
 
   // ── Insert allocations ────────────────────────────────────────────────────
-  const allocationRows = allPlannedItems.flatMap(({ plans, item }) =>
-    plans.map((plan) => ({
+  const allocationRows = allPlannedItems.flatMap(({ plans, item }) => {
+    const expenseId = expenseIdByLegCurrency[item.currency] ?? expenseIdByLegCurrency[from_currency]
+    if (!expenseId) return []
+
+    const expenseCurrency = getAllocationExpenseCurrency({
+      itemCurrency: item.currency,
+      expenseIdByLegCurrency,
+      fallbackCurrency: from_currency,
+    })
+
+    return plans.map((plan) => ({
       user_id: user.id,
-      expense_id: paymentExpense.id,
+      expense_id: expenseId,
       card_cycle_id: plan.cycle.id,
       amount_applied: plan.appliedAmount,
       currency: item.currency,
-      exchange_rate: item.currency !== from_currency ? (exchange_rate ?? null) : null,
-    })),
-  )
+      exchange_rate:
+        item.currency !== expenseCurrency && item.currency === 'USD' && expenseCurrency === 'ARS'
+          ? (exchange_rate ?? null)
+          : null,
+    }))
+  })
 
   let allocationsCreated = false
   const { error: allocationsError } = await supabase.from('card_payment_allocations').insert(allocationRows)
 
   if (allocationsError) {
     if (!isMissingCardPaymentAllocationsTableError(allocationsError.message)) {
-      await supabase.from('expenses').delete().eq('id', paymentExpense.id).eq('user_id', user.id)
+      const createdExpenseIds = getCreatedExpenseIds(expenseIdByLegCurrency)
+      if (createdExpenseIds.length > 0) {
+        await supabase.from('expenses').delete().eq('user_id', user.id).in('id', createdExpenseIds)
+      }
       for (const adjId of adjustmentExpenseIds) {
         await supabase.from('expenses').delete().eq('id', adjId).eq('user_id', user.id)
       }
@@ -629,7 +721,6 @@ export async function POST(request: Request) {
         .upsert(payload, { onConflict: 'card_cycle_id,currency' })
 
       if (error) {
-        // Rollback previously updated cycle amounts
         for (const updatedKey of updatedCycleKeys) {
           const [cycleId, currency] = updatedKey.split(':')
           const matchedPlan = allPlannedItems
@@ -652,15 +743,19 @@ export async function POST(request: Request) {
             )
         }
 
-        if (allocationsCreated) {
+        const createdExpenseIds = getCreatedExpenseIds(expenseIdByLegCurrency)
+
+        if (allocationsCreated && createdExpenseIds.length > 0) {
           await supabase
             .from('card_payment_allocations')
             .delete()
             .eq('user_id', user.id)
-            .eq('expense_id', paymentExpense.id)
+            .in('expense_id', createdExpenseIds)
         }
 
-        await supabase.from('expenses').delete().eq('id', paymentExpense.id).eq('user_id', user.id)
+        if (createdExpenseIds.length > 0) {
+          await supabase.from('expenses').delete().eq('user_id', user.id).in('id', createdExpenseIds)
+        }
         for (const adjId of adjustmentExpenseIds) {
           await supabase.from('expenses').delete().eq('id', adjId).eq('user_id', user.id)
         }
@@ -673,10 +768,12 @@ export async function POST(request: Request) {
   }
 
   const allPlans = allPlannedItems.flatMap((x) => x.plans)
+  const createdExpenseIds = getCreatedExpenseIds(expenseIdByLegCurrency)
 
   return NextResponse.json({
     ok: true,
-    expenseId: paymentExpense.id,
+    expenseId: createdExpenseIds[0] ?? null,
+    expenseIds: createdExpenseIds,
     cycleIds: allPlans.map((plan) => plan.cycle.id),
     allocationsCreated,
     fullySettled: allPlans.every((plan) => plan.next.status === 'paid'),

--- a/app/api/card-payments/route.ts
+++ b/app/api/card-payments/route.ts
@@ -308,8 +308,11 @@ async function buildPlansForItem(
     )
     const remainingAmount = getRemainingCardCycleAmount(statementAmount, originalCycle.amount_paid)
     const applyAllAsAdvance = !explicitCycle && originalCycle.closing_date >= paymentDate
+    const isFinalExplicitCycle = !!explicitCycle && index === targetCycles.length - 1
     const applyAmount = roundMoney(
-      applyAllAsAdvance ? remainingPayment : Math.min(remainingPayment, remainingAmount),
+      applyAllAsAdvance || isFinalExplicitCycle
+        ? remainingPayment
+        : Math.min(remainingPayment, remainingAmount),
     )
 
     if (applyAmount <= 0) continue

--- a/app/share-target/page.tsx
+++ b/app/share-target/page.tsx
@@ -1,0 +1,11 @@
+import { ShareTargetBridge } from '@/components/share-target/ShareTargetBridge'
+
+export default async function ShareTargetPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ shareTargetId?: string }>
+}) {
+  const { shareTargetId } = await searchParams
+
+  return <ShareTargetBridge shareTargetId={shareTargetId ?? null} />
+}

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -14,6 +14,7 @@ import { CardPaymentPrompt } from '@/components/dashboard/CardPaymentPrompt'
 import { SubscriptionReviewBanner } from '@/components/subscriptions/SubscriptionReviewBanner'
 import { InstrumentosCard } from '@/components/instruments/InstrumentosCard'
 import { RecurringIncomeBanner } from '@/components/dashboard/RecurringIncomeBanner'
+import { PendingSharedReceiptBanner } from '@/components/share-target/PendingSharedReceiptBanner'
 import { useCardPaymentPrompts } from '@/hooks/useCardPaymentPrompts'
 import { FF_INSTRUMENTS } from '@/lib/flags'
 import { trackEvent } from '@/lib/product-analytics/client'
@@ -245,6 +246,11 @@ export function DashboardShell({
           </button>
           <HomePlusButton accounts={accounts} currency={currency} cards={cards} month={selectedMonth} />
         </div>
+
+        <PendingSharedReceiptBanner
+          canOpenComposer={accounts.length > 0}
+          onOpenComposer={promptFirstExpense}
+        />
 
         {accounts.length === 0 ? (
           <section className="rounded-card border border-border-subtle bg-bg-secondary/70 px-5 py-6">

--- a/components/expenses/ExpenseItem.tsx
+++ b/components/expenses/ExpenseItem.tsx
@@ -89,6 +89,7 @@ export function ExpenseItem({ expense, cards, accounts, onUpdate }: Props) {
   const [isRecurring, setIsRecurring] = useState(expense.is_recurring ?? false)
   const [isExtraordinary, setIsExtraordinary] = useState(expense.is_extraordinary ?? false)
 
+  const isSubscriptionExpense = expense.subscription_id != null
   const isInstallmentGroup = expense.installment_group_id != null
   const canEditInstallmentGroup = isInstallmentGroup && (groupSummary?.first_installment_number ?? 1) === 1
 
@@ -311,11 +312,51 @@ export function ExpenseItem({ expense, cards, accounts, onUpdate }: Props) {
       }}>
         <div className="mx-auto mb-5 h-1 w-10 rounded-full bg-text-disabled sm:hidden" />
         <h2 className="text-lg font-semibold text-text-primary">
-          {isInstallmentGroup ? (editingGroup ? 'Editar compra en cuotas' : 'Detalle de cuota') : 'Editar gasto'}
+          {isSubscriptionExpense
+            ? 'Detalle de suscripción'
+            : isInstallmentGroup
+              ? (editingGroup ? 'Editar compra en cuotas' : 'Detalle de cuota')
+              : 'Editar gasto'}
         </h2>
 
-        {/* Vista read-only de cuota individual */}
-        {isInstallmentGroup && !editingGroup ? (
+        {/* Vista read-only de suscripción generada */}
+        {isSubscriptionExpense ? (
+          <div className="mt-5 space-y-5">
+            {error && <p className="text-xs text-danger">{error}</p>}
+
+            <div className="space-y-3 rounded-[14px] bg-bg-secondary px-4 py-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-text-primary">
+                    {expense.description || expense.category}
+                  </p>
+                  <p className="mt-0.5 text-xs text-text-tertiary">{expense.category}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-sm font-semibold tabular-nums text-text-primary">
+                    {formatAmount(expense.amount, expense.currency)}
+                  </p>
+                  <p className="text-[11px] text-text-tertiary">{expense.payment_method === 'CREDIT' ? 'Crédito' : 'Débito'}</p>
+                </div>
+              </div>
+              <p className="text-xs text-text-tertiary">{formatDate(expense.date)}</p>
+            </div>
+
+            <div className="rounded-[14px] border border-border-subtle bg-bg-secondary px-4 py-3">
+              <p className="text-sm font-medium text-text-primary">Este movimiento viene de una suscripción.</p>
+              <p className="mt-1 text-xs text-text-secondary">
+                Desde Movimientos y Últimos solo podés ver el cargo generado. Para cambiar monto, moneda, fecha o próximos cargos, editá la suscripción desde la sección Suscripciones.
+              </p>
+            </div>
+
+            <button
+              onClick={() => setOpen(false)}
+              className="w-full rounded-button bg-primary py-3 text-sm font-semibold text-white"
+            >
+              Entendido
+            </button>
+          </div>
+        ) : isInstallmentGroup && !editingGroup ? (
           <div className="mt-5 space-y-5">
             {error && <p className="text-xs text-danger">{error}</p>}
 

--- a/components/share-target/PendingSharedReceiptBanner.tsx
+++ b/components/share-target/PendingSharedReceiptBanner.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { trackEvent } from '@/lib/product-analytics/client'
+import {
+  clearPendingSharedReceipt,
+  consumeShareTargetFocusRequest,
+  readPendingSharedReceipt,
+  readSharedReceiptFile,
+  type PendingSharedReceipt,
+} from '@/lib/share-target'
+
+interface PendingSharedReceiptBannerProps {
+  canOpenComposer: boolean
+  onOpenComposer: () => void
+}
+
+function bucketSharedFileType(type: string): 'image' | 'other' {
+  return type.startsWith('image/') ? 'image' : 'other'
+}
+
+export function PendingSharedReceiptBanner({
+  canOpenComposer,
+  onOpenComposer,
+}: PendingSharedReceiptBannerProps) {
+  const [pendingShare, setPendingShare] = useState<PendingSharedReceipt | null>(null)
+  const trackedReadyRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const syncPendingShare = async () => {
+      const stored = readPendingSharedReceipt()
+      if (!stored) {
+        if (!cancelled) setPendingShare(null)
+        return
+      }
+
+      const file = await readSharedReceiptFile(stored.id)
+      if (!file) {
+        await clearPendingSharedReceipt(stored.id)
+        if (!cancelled) setPendingShare(null)
+        return
+      }
+
+      if (cancelled) return
+      setPendingShare(stored)
+
+      if (trackedReadyRef.current !== stored.id) {
+        trackedReadyRef.current = stored.id
+        console.info('[share-target] pending share ready in dashboard', {
+          id: stored.id,
+          type: stored.type,
+          size: stored.size,
+        })
+        trackEvent('share_target_ready', {
+          file_kind: bucketSharedFileType(stored.type),
+          has_file: true,
+        })
+      }
+
+      if (canOpenComposer && consumeShareTargetFocusRequest()) {
+        onOpenComposer()
+      }
+    }
+
+    void syncPendingShare()
+    window.addEventListener('focus', syncPendingShare)
+
+    return () => {
+      cancelled = true
+      window.removeEventListener('focus', syncPendingShare)
+    }
+  }, [canOpenComposer, onOpenComposer])
+
+  if (!pendingShare) return null
+
+  const handleDismiss = async () => {
+    await clearPendingSharedReceipt(pendingShare.id)
+    setPendingShare(null)
+  }
+
+  return (
+    <section className="rounded-card border border-primary/20 bg-primary/8 px-4 py-4">
+      <p className="type-label text-primary">Captura compartida</p>
+      <h2 className="mt-2 text-[18px] font-semibold tracking-[-0.02em] text-text-primary">
+        Tu archivo ya llegó a Gota
+      </h2>
+      <p className="mt-2 text-sm leading-6 text-text-secondary">
+        {canOpenComposer
+          ? 'Lo guardamos en este dispositivo y lo dejamos listo para seguir la carga desde el Home.'
+          : 'Lo guardamos en este dispositivo. Primero necesitás crear una cuenta y después vas a poder seguir la carga desde el Home.'}
+      </p>
+      <p className="mt-3 text-xs text-text-secondary">
+        {pendingShare.name} · {pendingShare.type || 'archivo'}
+      </p>
+      <div className="mt-4 flex flex-wrap gap-3">
+        {canOpenComposer && (
+          <button
+            type="button"
+            onClick={onOpenComposer}
+            className="rounded-button bg-primary px-4 py-3 text-sm font-semibold text-white transition-colors hover:brightness-105"
+          >
+            Abrir carga
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => {
+            void handleDismiss()
+          }}
+          className="rounded-button border border-border-subtle px-4 py-3 text-sm font-semibold text-text-secondary transition-colors hover:bg-white/60"
+        >
+          Descartar captura
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/components/share-target/ShareTargetBridge.tsx
+++ b/components/share-target/ShareTargetBridge.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import { trackEvent } from '@/lib/product-analytics/client'
+import {
+  hydratePendingSharedReceipt,
+  requestShareTargetFocus,
+  type PendingSharedReceipt,
+} from '@/lib/share-target'
+
+interface ShareTargetBridgeProps {
+  shareTargetId: string | null
+}
+
+function bucketSharedFileType(type: string): 'image' | 'other' {
+  return type.startsWith('image/') ? 'image' : 'other'
+}
+
+export function ShareTargetBridge({ shareTargetId }: ShareTargetBridgeProps) {
+  const supabase = useMemo(() => createClient(), [])
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const redirectWithPendingShare = async (receipt: PendingSharedReceipt) => {
+      requestShareTargetFocus()
+      console.info('[share-target] pending share hydrated', {
+        id: receipt.id,
+        name: receipt.name,
+        type: receipt.type,
+        size: receipt.size,
+      })
+      trackEvent('share_target_received', {
+        file_kind: bucketSharedFileType(receipt.type),
+        has_file: true,
+      })
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+
+      if (cancelled) return
+      window.location.replace(user ? '/' : '/login')
+    }
+
+    const run = async () => {
+      if (!shareTargetId) {
+        console.warn('[share-target] missing shareTargetId')
+        trackEvent('share_target_failed', { reason: 'missing_id' })
+        setError('Falta identificar el archivo compartido.')
+        return
+      }
+
+      const receipt = await hydratePendingSharedReceipt(shareTargetId)
+      if (!receipt) {
+        console.warn('[share-target] shared payload not found in cache', { shareTargetId })
+        trackEvent('share_target_failed', { reason: 'cache_miss' })
+        setError('No encontramos la captura compartida. Intentá compartirla de nuevo.')
+        return
+      }
+
+      await redirectWithPendingShare(receipt)
+    }
+
+    void run()
+
+    return () => {
+      cancelled = true
+    }
+  }, [shareTargetId, supabase])
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-bg-primary px-6 text-center">
+      <div className="max-w-sm rounded-card border border-border-subtle bg-bg-secondary/70 px-5 py-6 shadow-sm">
+        <p className="type-label text-text-secondary">Share target</p>
+        <h1 className="mt-3 text-[24px] font-bold tracking-[-0.03em] text-text-primary">
+          {error ? 'No pudimos abrir la captura' : 'Preparando tu captura'}
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-text-secondary">
+          {error
+            ? error
+            : 'Guardamos el archivo compartido y te redirigimos al Home para seguir la carga sin romper la sesión.'}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/tour/TourOverlay.tsx
+++ b/components/tour/TourOverlay.tsx
@@ -46,7 +46,9 @@ export function TourOverlay() {
   }, [step, updateRect])
 
   useEffect(() => {
-    updateRect()
+    const frameId = window.requestAnimationFrame(() => {
+      updateRect()
+    })
 
     const handleScroll = () => updateRect()
     const handleResize = () => updateRect()
@@ -61,6 +63,7 @@ export function TourOverlay() {
     }
 
     return () => {
+      window.cancelAnimationFrame(frameId)
       window.removeEventListener('scroll', handleScroll, true)
       window.removeEventListener('resize', handleResize)
       observerRef.current?.disconnect()

--- a/lib/card-cycle-assignment.ts
+++ b/lib/card-cycle-assignment.ts
@@ -1,5 +1,5 @@
 import { addMonths } from '@/lib/dates'
-import { buildCycleDate } from '@/lib/card-cycles'
+import { buildCycleDate, resolveDueMonth } from '@/lib/card-cycles'
 import type { createClient } from '@/lib/supabase/server'
 import type { Card, CardCycle } from '@/types/database'
 
@@ -19,7 +19,7 @@ function getCyclePeriodMonthForDate(card: Pick<Card, 'closing_day'>, date: strin
 
 function buildCyclePayload(userId: string, card: Card, periodMonth: string) {
   const closingDate = buildCycleDate(periodMonth, card.closing_day ?? 1)
-  const dueMonth = addMonths(periodMonth, 1)
+  const dueMonth = resolveDueMonth(periodMonth, card.closing_day, card.due_day)
   const dueDate = buildCycleDate(dueMonth, card.due_day ?? Math.min((card.closing_day ?? 1) + 10, 31))
 
   return {

--- a/lib/card-cycle-payments.test.ts
+++ b/lib/card-cycle-payments.test.ts
@@ -53,6 +53,23 @@ describe('card-cycle-payments', () => {
     expect(result.remainingAmount).toBe(0)
   })
 
+  it('closes a documented overpayment when the paid amount includes the adjustment', () => {
+    const result = resolveCardCyclePayment({
+      statementAmount: 1000,
+      amountPaid: null,
+      paymentAmount: 1100,
+      paymentDate: '2026-04-25',
+      closingDate: '2026-04-10',
+      adjustmentAmount: 100,
+    })
+
+    expect(result.status).toBe('paid')
+    expect(result.effectiveStatementAmount).toBe(1100)
+    expect(result.nextAmountPaid).toBe(1100)
+    expect(result.remainingAmount).toBe(0)
+    expect(result.snapshotAmountDraft).toBe(1100)
+  })
+
   it('treats payments on an open cycle as prepayments', () => {
     const result = resolveCardCyclePayment({
       statementAmount: 800,

--- a/lib/card-cycles.test.ts
+++ b/lib/card-cycles.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { buildLegacyCardCycle, resolveDueMonth } from '@/lib/card-cycles'
+import type { Card } from '@/types/database'
+
+function makeCard(overrides: Partial<Card>): Card {
+  return {
+    id: 'card-1',
+    user_id: 'user-1',
+    name: 'Test card',
+    closing_day: 12,
+    due_day: 17,
+    account_id: null,
+    archived: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('card cycle due date resolution', () => {
+  it('keeps due date in the same period month when due_day is after closing_day', () => {
+    expect(resolveDueMonth('2026-05', 12, 17)).toBe('2026-05')
+
+    const cycle = buildLegacyCardCycle(makeCard({ closing_day: 12, due_day: 17 }), '2026-05')
+    expect(cycle.closing_date).toBe('2026-05-12')
+    expect(cycle.due_date).toBe('2026-05-17')
+  })
+
+  it('moves due date to the next month when due_day is on or before closing_day', () => {
+    expect(resolveDueMonth('2026-05', 26, 1)).toBe('2026-06')
+    expect(resolveDueMonth('2026-05', 12, 12)).toBe('2026-06')
+
+    const cycle = buildLegacyCardCycle(makeCard({ closing_day: 26, due_day: 1 }), '2026-05')
+    expect(cycle.closing_date).toBe('2026-05-26')
+    expect(cycle.due_date).toBe('2026-06-01')
+  })
+})

--- a/lib/card-cycles.ts
+++ b/lib/card-cycles.ts
@@ -22,10 +22,16 @@ export function buildCycleDate(periodMonth: string, day: number | null): string 
   return `${periodMonth}-${String(normalizedDay).padStart(2, '0')}`
 }
 
+export function resolveDueMonth(periodMonth: string, closingDay: number | null, dueDay: number | null): string {
+  const safeClosingDay = closingDay ?? 1
+  const safeDueDay = dueDay ?? Math.min(safeClosingDay + 10, 31)
+  return safeDueDay > safeClosingDay ? periodMonth : addMonths(periodMonth, 1)
+}
+
 export function buildLegacyCardCycle(card: Card, periodMonth: string): ResolvedCardCycle {
   const closingDate = buildCycleDate(periodMonth, card.closing_day ?? 1)
-  const nextMonth = addMonths(periodMonth, 1)
-  const dueDate = buildCycleDate(nextMonth, card.due_day ?? Math.min((card.closing_day ?? 1) + 10, 31))
+  const dueMonth = resolveDueMonth(periodMonth, card.closing_day, card.due_day)
+  const dueDate = buildCycleDate(dueMonth, card.due_day ?? Math.min((card.closing_day ?? 1) + 10, 31))
 
   return {
     id: `legacy-${card.id}-${periodMonth}`,

--- a/lib/product-analytics/events.ts
+++ b/lib/product-analytics/events.ts
@@ -18,6 +18,9 @@ export const PRODUCT_EVENT_NAMES = [
   'card_payment_prompt_confirmed',
   'card_payment_prompt_dismissed',
   'dashboard_loaded_with_data',
+  'share_target_received',
+  'share_target_ready',
+  'share_target_failed',
 ] as const
 
 export type ProductEventName = (typeof PRODUCT_EVENT_NAMES)[number]

--- a/lib/share-target.test.ts
+++ b/lib/share-target.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  SHARE_TARGET_FOCUS_KEY,
+  SHARE_TARGET_STORAGE_KEY,
+  buildShareTargetCacheUrl,
+  clearPendingSharedReceipt,
+  consumeShareTargetFocusRequest,
+  hydratePendingSharedReceipt,
+  persistPendingSharedReceipt,
+  readPendingSharedReceipt,
+  readSharedReceiptFile,
+  requestShareTargetFocus,
+} from './share-target'
+
+type StoredResponse = {
+  blob: () => Promise<Blob>
+  headers: Headers
+}
+
+class MemoryStorage {
+  private values = new Map<string, string>()
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+
+  clear() {
+    this.values.clear()
+  }
+}
+
+class MemoryCache {
+  private entries = new Map<string, StoredResponse>()
+
+  async match(request: string) {
+    return this.entries.get(request) ?? null
+  }
+
+  async put(request: string, response: StoredResponse) {
+    this.entries.set(request, response)
+  }
+
+  async delete(request: string) {
+    return this.entries.delete(request)
+  }
+
+  async keys() {
+    return Array.from(this.entries.keys()).map((url) => ({ url }))
+  }
+}
+
+describe('share-target helpers', () => {
+  const originalWindow = globalThis.window
+  const storage = new MemoryStorage()
+  const cache = new MemoryCache()
+
+  beforeEach(() => {
+    storage.clear()
+    ;(globalThis as { window?: Window }).window = {
+      localStorage: storage,
+      caches: {
+        open: async () => cache,
+      },
+    } as unknown as Window
+  })
+
+  afterEach(() => {
+    if (originalWindow) {
+      ;(globalThis as { window?: Window }).window = originalWindow
+    } else {
+      delete (globalThis as { window?: Window }).window
+    }
+  })
+
+  it('builds deterministic cache URLs', () => {
+    expect(buildShareTargetCacheUrl('share-123')).toBe('/__share-target/share-123')
+  })
+
+  it('persists pending receipt metadata in localStorage', () => {
+    persistPendingSharedReceipt({
+      id: 'share-123',
+      name: 'ticket.png',
+      type: 'image/png',
+      size: 2048,
+      createdAt: '2026-05-19T00:00:00.000Z',
+    })
+
+    expect(readPendingSharedReceipt()).toEqual({
+      id: 'share-123',
+      name: 'ticket.png',
+      type: 'image/png',
+      size: 2048,
+      createdAt: '2026-05-19T00:00:00.000Z',
+    })
+  })
+
+  it('stores and consumes the focus flag once', () => {
+    requestShareTargetFocus()
+
+    expect(storage.getItem(SHARE_TARGET_FOCUS_KEY)).toBe('1')
+    expect(consumeShareTargetFocusRequest()).toBe(true)
+    expect(consumeShareTargetFocusRequest()).toBe(false)
+  })
+
+  it('hydrates a cached shared file into pending receipt metadata', async () => {
+    const createdAt = '2026-05-19T12:34:56.000Z'
+    await cache.put(buildShareTargetCacheUrl('share-456'), {
+      blob: async () => new Blob(['png-bytes'], { type: 'image/png' }),
+      headers: new Headers({
+        'content-type': 'image/png',
+        'x-gota-share-created-at': createdAt,
+        'x-gota-share-filename': 'captura.png',
+      }),
+    })
+
+    await expect(readSharedReceiptFile('share-456')).resolves.toMatchObject({
+      name: 'captura.png',
+      type: 'image/png',
+      size: 9,
+      lastModified: Date.parse(createdAt),
+    })
+
+    await expect(hydratePendingSharedReceipt('share-456')).resolves.toEqual({
+      id: 'share-456',
+      name: 'captura.png',
+      type: 'image/png',
+      size: 9,
+      createdAt,
+    })
+
+    expect(JSON.parse(storage.getItem(SHARE_TARGET_STORAGE_KEY) ?? 'null')).toEqual({
+      id: 'share-456',
+      name: 'captura.png',
+      type: 'image/png',
+      size: 9,
+      createdAt,
+    })
+  })
+
+  it('clears both local metadata and cached file contents', async () => {
+    persistPendingSharedReceipt({
+      id: 'share-789',
+      name: 'captura.png',
+      type: 'image/png',
+      size: 9,
+      createdAt: '2026-05-19T12:34:56.000Z',
+    })
+    requestShareTargetFocus()
+    await cache.put(buildShareTargetCacheUrl('share-789'), {
+      blob: async () => new Blob(['png-bytes'], { type: 'image/png' }),
+      headers: new Headers({
+        'content-type': 'image/png',
+      }),
+    })
+
+    await clearPendingSharedReceipt('share-789')
+
+    expect(storage.getItem(SHARE_TARGET_STORAGE_KEY)).toBeNull()
+    expect(storage.getItem(SHARE_TARGET_FOCUS_KEY)).toBeNull()
+    await expect(cache.match(buildShareTargetCacheUrl('share-789'))).resolves.toBeNull()
+  })
+})

--- a/lib/share-target.ts
+++ b/lib/share-target.ts
@@ -1,0 +1,133 @@
+'use client'
+
+export const SHARE_TARGET_CACHE = 'gota-v1-share-target'
+export const SHARE_TARGET_STORAGE_KEY = 'gota.share-target.pending'
+export const SHARE_TARGET_FOCUS_KEY = 'gota.share-target.focus'
+const SHARE_TARGET_PREFIX = '/__share-target/'
+
+export interface PendingSharedReceipt {
+  id: string
+  name: string
+  type: string
+  size: number
+  createdAt: string
+}
+
+export function buildShareTargetCacheUrl(id: string): string {
+  return `/__share-target/${id}`
+}
+
+async function clearCachedSharedReceipts(cache: Cache): Promise<void> {
+  const requests = await cache.keys()
+  await Promise.all(
+    requests
+      .filter((request) => new URL(request.url).pathname.startsWith(SHARE_TARGET_PREFIX))
+      .map((request) => cache.delete(request))
+  )
+}
+
+export function readPendingSharedReceipt(): PendingSharedReceipt | null {
+  if (typeof window === 'undefined') return null
+
+  try {
+    const raw = window.localStorage.getItem(SHARE_TARGET_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as PendingSharedReceipt
+    if (!parsed?.id) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export function persistPendingSharedReceipt(receipt: PendingSharedReceipt): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    window.localStorage.setItem(SHARE_TARGET_STORAGE_KEY, JSON.stringify(receipt))
+  } catch {
+    // localStorage failures should not block the share flow.
+  }
+}
+
+export function requestShareTargetFocus(): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    window.localStorage.setItem(SHARE_TARGET_FOCUS_KEY, '1')
+  } catch {
+    // Ignore focus persistence failures.
+  }
+}
+
+export function consumeShareTargetFocusRequest(): boolean {
+  if (typeof window === 'undefined') return false
+
+  try {
+    const shouldFocus = window.localStorage.getItem(SHARE_TARGET_FOCUS_KEY) === '1'
+    if (shouldFocus) {
+      window.localStorage.removeItem(SHARE_TARGET_FOCUS_KEY)
+    }
+    return shouldFocus
+  } catch {
+    return false
+  }
+}
+
+export async function readSharedReceiptFile(id: string): Promise<File | null> {
+  if (typeof window === 'undefined' || !('caches' in window)) return null
+
+  const cache = await window.caches.open(SHARE_TARGET_CACHE)
+  const response = await cache.match(buildShareTargetCacheUrl(id))
+  if (!response) return null
+
+  const blob = await response.blob()
+  const type = response.headers.get('content-type') || blob.type || 'application/octet-stream'
+  const name = response.headers.get('x-gota-share-filename') || `share-${id}`
+  const createdAt = response.headers.get('x-gota-share-created-at')
+  const lastModified = createdAt ? Date.parse(createdAt) : Date.now()
+
+  return new File([blob], name, {
+    type,
+    lastModified: Number.isFinite(lastModified) ? lastModified : Date.now(),
+  })
+}
+
+export async function hydratePendingSharedReceipt(id: string): Promise<PendingSharedReceipt | null> {
+  const file = await readSharedReceiptFile(id)
+  if (!file) return null
+
+  const receipt: PendingSharedReceipt = {
+    id,
+    name: file.name,
+    type: file.type,
+    size: file.size,
+    createdAt: new Date(file.lastModified).toISOString(),
+  }
+
+  persistPendingSharedReceipt(receipt)
+  return receipt
+}
+
+export async function clearPendingSharedReceipt(id?: string): Promise<void> {
+  if (typeof window === 'undefined') return
+
+  const targetId = id ?? readPendingSharedReceipt()?.id
+
+  try {
+    window.localStorage.removeItem(SHARE_TARGET_STORAGE_KEY)
+    window.localStorage.removeItem(SHARE_TARGET_FOCUS_KEY)
+  } catch {
+    // Ignore localStorage failures.
+  }
+
+  if (!('caches' in window)) return
+
+  const cache = await window.caches.open(SHARE_TARGET_CACHE)
+  if (!targetId) {
+    await clearCachedSharedReceipts(cache)
+    return
+  }
+
+  await cache.delete(buildShareTargetCacheUrl(targetId))
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -37,7 +37,8 @@ export async function proxy(request: NextRequest) {
   if (
     !user &&
     !request.nextUrl.pathname.startsWith('/login') &&
-    !request.nextUrl.pathname.startsWith('/auth/')
+    !request.nextUrl.pathname.startsWith('/auth/') &&
+    !request.nextUrl.pathname.startsWith('/share-target')
   ) {
     return NextResponse.redirect(new URL('/login', request.url))
   }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,6 +7,19 @@
   "background_color": "#F0F4F8",
   "theme_color": "#2178A8",
   "orientation": "portrait",
+  "share_target": {
+    "action": "/share-target",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "files": [
+        {
+          "name": "receipt",
+          "accept": ["image/*"]
+        }
+      ]
+    }
+  },
   "icons": [
     { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,8 +1,70 @@
 const CACHE_VERSION = 'gota-v1'
 const STATIC_CACHE = `${CACHE_VERSION}-static`
+const SHARE_TARGET_CACHE = `${CACHE_VERSION}-share-target`
+const SHARE_TARGET_PREFIX = '/__share-target/'
+
+function buildShareTargetCacheUrl(shareTargetId) {
+  return `${self.location.origin}${SHARE_TARGET_PREFIX}${shareTargetId}`
+}
+
+async function clearCachedSharedReceipts(cache) {
+  const keys = await cache.keys()
+  await Promise.all(
+    keys
+      .filter((request) => new URL(request.url).pathname.startsWith(SHARE_TARGET_PREFIX))
+      .map((request) => cache.delete(request))
+  )
+}
+
+async function handleShareTarget(request) {
+  try {
+    const formData = await request.formData()
+    const sharedFile = formData.get('receipt')
+
+    if (!(sharedFile instanceof File)) {
+      console.warn('[share-target] No file found in shared payload')
+      return Response.redirect(`${self.location.origin}/share-target`, 303)
+    }
+
+    const shareTargetId =
+      typeof self.crypto?.randomUUID === 'function'
+        ? self.crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(16).slice(2)}`
+    const createdAt = new Date().toISOString()
+    const cache = await caches.open(SHARE_TARGET_CACHE)
+
+    await clearCachedSharedReceipts(cache)
+
+    await cache.put(
+      buildShareTargetCacheUrl(shareTargetId),
+      new Response(sharedFile, {
+        headers: {
+          'content-type': sharedFile.type || 'application/octet-stream',
+          'cache-control': 'no-store',
+          'x-gota-share-created-at': createdAt,
+          'x-gota-share-filename': sharedFile.name || 'captura-compartida',
+        },
+      })
+    )
+
+    console.info('[share-target] Shared file stored', {
+      shareTargetId,
+      name: sharedFile.name,
+      type: sharedFile.type,
+      size: sharedFile.size,
+    })
+
+    const redirectUrl = new URL('/share-target', self.location.origin)
+    redirectUrl.searchParams.set('shareTargetId', shareTargetId)
+    return Response.redirect(redirectUrl.toString(), 303)
+  } catch (error) {
+    console.error('[share-target] Failed to handle shared payload', error)
+    return Response.redirect(`${self.location.origin}/share-target`, 303)
+  }
+}
 
 // Cache Next.js static assets on install
-self.addEventListener('install', (event) => {
+self.addEventListener('install', () => {
   self.skipWaiting()
 })
 
@@ -14,7 +76,7 @@ self.addEventListener('activate', (event) => {
       .then((keys) =>
         Promise.all(
           keys
-            .filter((key) => key !== STATIC_CACHE)
+            .filter((key) => key !== STATIC_CACHE && key !== SHARE_TARGET_CACHE)
             .map((key) => caches.delete(key))
         )
       )
@@ -25,6 +87,11 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const { request } = event
   const url = new URL(request.url)
+
+  if (request.method === 'POST' && url.origin === self.location.origin && url.pathname === '/share-target') {
+    event.respondWith(handleShareTarget(request))
+    return
+  }
 
   // Never intercept: API calls, auth, or cross-origin requests
   if (


### PR DESCRIPTION
## Summary
- Adds PWA share target intake flow for shared receipts
- Persists shared payloads, rehydrates in the dashboard, and shows pending capture banner
- Updates manifest/service worker/proxy plumbing and adds tests

## Verification
- npm test
- npm run lint
- npx --no-install tsc --noEmit
- npm run build

## Notes
- Commit: 48ebdc5