### PR TITLE
feat(exploration): mobile UI exploration — 3 visual directions for Home + TabBar

### DIFF
--- a/app/(exploration)/layout.tsx
+++ b/app/(exploration)/layout.tsx
@@ -1,0 +1,10 @@
+// THROWAWAY — solo para exploración visual. No forma parte de la app.
+export default function ExplorationLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="es">
+      <body style={{ margin: 0, background: '#F0F4F8', fontFamily: 'system-ui, sans-serif' }}>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/app/(exploration)/ui-exploration/page.tsx
+++ b/app/(exploration)/ui-exploration/page.tsx
@@ -1,0 +1,65 @@
+// THROWAWAY — artefacto de exploración visual. No modifica lógica de negocio.
+// Acceder en desarrollo: /ui-exploration
+// Eliminar antes de merge a main.
+
+import { VariantA } from '@/components/_exploration/VariantA'
+import { VariantB } from '@/components/_exploration/VariantB'
+import { VariantC } from '@/components/_exploration/VariantC'
+
+export default function UIExplorationPage() {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: '#E8EFF5',
+        padding: '24px 16px',
+        fontFamily:
+          '-apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, sans-serif',
+      }}
+    >
+      <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+        <div
+          style={{
+            background: '#1A2B3C',
+            color: '#E0F0FF',
+            borderRadius: 12,
+            padding: '16px 20px',
+            marginBottom: 32,
+          }}
+        >
+          <p
+            style={{
+              margin: 0,
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              color: '#6BB8E8',
+            }}
+          >
+            Exploración visual — throwaway
+          </p>
+          <h1 style={{ margin: '4px 0 0', fontSize: 18, fontWeight: 700, color: '#FFFFFF' }}>
+            Gota Mobile UI · 3 Direcciones
+          </h1>
+          <p style={{ margin: '6px 0 0', fontSize: 13, color: '#90B8D0' }}>
+            Variante A: Fintech Calma / Premium · B: Nativa Operativa / Densa · C: Híbrida Sobria
+          </p>
+        </div>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+            gap: 32,
+            alignItems: 'start',
+          }}
+        >
+          <VariantA />
+          <VariantB />
+          <VariantC />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/_exploration/VariantA.tsx
+++ b/components/_exploration/VariantA.tsx
@@ -1,0 +1,394 @@
+// THROWAWAY — Variante A: Fintech Calma / Premium
+// No modifica lógica ni componentes de producción.
+
+import {
+  PhoneFrame,
+  Avatar,
+  PlusBtn,
+  CategoryDot,
+  MOCK_BALANCE,
+  MOCK_DISPONIBLE,
+  MOCK_COMPROMISOS,
+  MOCK_MOVEMENTS,
+  tokens,
+} from './shared'
+
+export function VariantA() {
+  return (
+    <PhoneFrame
+      label="Fintech Calma / Premium"
+      tag="Variante A"
+      tagColor="#1A4A6A"
+    >
+      {/* Safe area top */}
+      <div style={{ paddingTop: 16 }} />
+
+      {/* ── HEADER ────────────────────────────────────────── */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 20px 12px',
+        }}
+      >
+        <Avatar />
+        {/* Month pill — centered */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+            background: tokens.bgTertiary,
+            borderRadius: 20,
+            padding: '5px 12px',
+            fontSize: 13,
+            fontWeight: 600,
+            color: tokens.textSecondary,
+          }}
+        >
+          Mayo
+          <span style={{ fontSize: 10, color: tokens.textDim, marginLeft: 2 }}>▾</span>
+        </div>
+        <PlusBtn />
+      </div>
+
+      {/* ── HERO CARD (full-width, glass-tinted) ─────────── */}
+      <div
+        style={{
+          margin: '0 16px 20px',
+          borderRadius: 22,
+          background: 'linear-gradient(145deg, rgba(33,120,168,0.07) 0%, rgba(27,126,158,0.04) 100%)',
+          border: '1px solid rgba(33,120,168,0.10)',
+          padding: '22px 20px 18px',
+        }}
+      >
+        {/* Label + eye toggle */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 8,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: '0.09em',
+              textTransform: 'uppercase',
+              color: tokens.textDim,
+            }}
+          >
+            Saldo Vivo
+          </span>
+          <span style={{ fontSize: 14, color: tokens.textDim }}>◎</span>
+        </div>
+
+        {/* Hero number */}
+        <div
+          style={{
+            fontSize: 42,
+            fontWeight: 800,
+            color: tokens.textPrimary,
+            letterSpacing: '-0.03em',
+            lineHeight: 1.1,
+            marginBottom: 8,
+          }}
+        >
+          {MOCK_BALANCE}
+        </div>
+
+        {/* ARS/USD breakdown pills */}
+        <div style={{ display: 'flex', gap: 8, marginBottom: 18 }}>
+          <span
+            style={{
+              background: tokens.primarySoft,
+              borderRadius: 8,
+              padding: '3px 8px',
+              fontSize: 11,
+              fontWeight: 600,
+              color: tokens.primary,
+            }}
+          >
+            ARS 1.240.500
+          </span>
+          <span
+            style={{
+              background: 'rgba(27,126,158,0.09)',
+              borderRadius: 8,
+              padding: '3px 8px',
+              fontSize: 11,
+              fontWeight: 600,
+              color: '#1B7E9E',
+            }}
+          >
+            USD 1.240
+          </span>
+        </div>
+
+        {/* Divider */}
+        <div
+          style={{
+            height: 1,
+            background: 'rgba(33,120,168,0.10)',
+            marginBottom: 14,
+          }}
+        />
+
+        {/* Disponible Real + Compromisos row */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <div>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 12,
+                color: tokens.textDim,
+                marginBottom: 2,
+              }}
+            >
+              Disponible real
+            </p>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 16,
+                fontWeight: 700,
+                color: tokens.success,
+              }}
+            >
+              {MOCK_DISPONIBLE}
+            </p>
+          </div>
+          <div style={{ textAlign: 'right' }}>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 12,
+                color: tokens.textDim,
+                marginBottom: 2,
+              }}
+            >
+              Compromisos
+            </p>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 16,
+                fontWeight: 700,
+                color: tokens.warning,
+              }}
+            >
+              {MOCK_COMPROMISOS}
+            </p>
+          </div>
+        </div>
+
+        {/* Progress bar */}
+        <div
+          style={{
+            height: 4,
+            borderRadius: 4,
+            background: tokens.separator,
+            marginTop: 12,
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              height: '100%',
+              width: '21%',
+              background: tokens.warning,
+              borderRadius: 4,
+            }}
+          />
+        </div>
+      </div>
+
+      {/* ── SECTION HEADER ───────────────────────────────── */}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '0 20px 10px',
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.09em',
+            textTransform: 'uppercase',
+            color: tokens.textDim,
+          }}
+        >
+          Últimos movimientos
+        </span>
+        <span style={{ fontSize: 12, color: tokens.primary, fontWeight: 600 }}>
+          Ver todos →
+        </span>
+      </div>
+
+      {/* ── MOVEMENTS LIST ───────────────────────────────── */}
+      <div style={{ padding: '0 16px' }}>
+        {MOCK_MOVEMENTS.map((mv, i) => (
+          <div
+            key={i}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              padding: '11px 4px',
+              borderBottom:
+                i < MOCK_MOVEMENTS.length - 1
+                  ? `1px solid ${tokens.separator}`
+                  : 'none',
+            }}
+          >
+            <CategoryDot color={mv.color} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: 14,
+                  fontWeight: 600,
+                  color: tokens.textPrimary,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {mv.label}
+              </p>
+              <p
+                style={{
+                  margin: '2px 0 0',
+                  fontSize: 12,
+                  color: tokens.textDim,
+                }}
+              >
+                {mv.cat} · {mv.date}
+              </p>
+            </div>
+            <span
+              style={{
+                fontSize: 14,
+                fontWeight: 700,
+                color: mv.amount.startsWith('+') ? tokens.success : tokens.textPrimary,
+                flexShrink: 0,
+              }}
+            >
+              {mv.amount}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* ── BOTTOM ZONE ──────────────────────────────────── */}
+      {/* SmartInput (collapsed) */}
+      <div style={{ flex: 1 }} />
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          background: 'rgba(255,255,255,0.97)',
+          backdropFilter: 'blur(16px)',
+          borderTop: `1px solid ${tokens.separator}`,
+          paddingBottom: 24,
+        }}
+      >
+        {/* SmartInput pill */}
+        <div style={{ padding: '10px 16px 6px' }}>
+          <div
+            style={{
+              background: 'rgba(190,225,248,0.28)',
+              border: '1px solid rgba(255,255,255,0.90)',
+              borderRadius: 16,
+              padding: '12px 16px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+            }}
+          >
+            <span style={{ fontSize: 14, color: tokens.textDim, flex: 1 }}>
+              ¿Qué gastaste?
+            </span>
+            <div
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: '50%',
+                background: tokens.primary,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#fff',
+                fontSize: 16,
+                flexShrink: 0,
+              }}
+            >
+              ✦
+            </div>
+          </div>
+        </div>
+
+        {/* TabBar — pills on active */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-around',
+            padding: '4px 20px 0',
+          }}
+        >
+          {[
+            { icon: '⌂', label: 'Home', active: true },
+            { icon: '≡', label: 'Movimientos', active: false },
+            { icon: '◷', label: 'Análisis', active: false },
+          ].map((tab) => (
+            <div
+              key={tab.label}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 4,
+                padding: '6px 16px',
+                borderRadius: 14,
+                background: tab.active ? tokens.primarySoft : 'transparent',
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 18,
+                  color: tab.active ? tokens.primary : tokens.textDim,
+                  lineHeight: 1,
+                }}
+              >
+                {tab.icon}
+              </span>
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: tab.active ? 700 : 400,
+                  color: tab.active ? tokens.primary : tokens.textDim,
+                }}
+              >
+                {tab.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </PhoneFrame>
+  )
+}

--- a/components/_exploration/VariantB.tsx
+++ b/components/_exploration/VariantB.tsx
@@ -1,0 +1,453 @@
+// THROWAWAY — Variante B: Nativa Operativa / Densa
+// No modifica lógica ni componentes de producción.
+
+import {
+  PhoneFrame,
+  Avatar,
+  PlusBtn,
+  CategoryDot,
+  MOCK_BALANCE,
+  MOCK_DISPONIBLE,
+  MOCK_COMPROMISOS,
+  MOCK_MOVEMENTS,
+  tokens,
+} from './shared'
+
+export function VariantB() {
+  return (
+    <PhoneFrame
+      label="Nativa Operativa / Densa"
+      tag="Variante B"
+      tagColor="#1A4A2A"
+    >
+      {/* Safe area top */}
+      <div style={{ paddingTop: 16 }} />
+
+      {/* ── HEADER: mes + avatar + plus, una sola fila ───── */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 16px 10px',
+        }}
+      >
+        <Avatar size={32} />
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+        >
+          <span
+            style={{
+              fontSize: 16,
+              fontWeight: 800,
+              color: tokens.textPrimary,
+              letterSpacing: '-0.01em',
+            }}
+          >
+            Mayo 2026
+          </span>
+        </div>
+        <PlusBtn size={32} />
+      </div>
+
+      {/* ── HERO COMPACTO: balance + quick stats ─────────── */}
+      <div
+        style={{
+          margin: '0 12px 12px',
+          borderRadius: 16,
+          background: tokens.bgSecondary,
+          border: `1px solid ${tokens.separator}`,
+          padding: '14px 16px',
+        }}
+      >
+        {/* Balance row */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            justifyContent: 'space-between',
+            marginBottom: 12,
+          }}
+        >
+          <div>
+            <p
+              style={{
+                margin: '0 0 3px',
+                fontSize: 11,
+                fontWeight: 700,
+                letterSpacing: '0.08em',
+                textTransform: 'uppercase',
+                color: tokens.textDim,
+              }}
+            >
+              Saldo Vivo
+            </p>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 30,
+                fontWeight: 800,
+                color: tokens.textPrimary,
+                letterSpacing: '-0.02em',
+              }}
+            >
+              {MOCK_BALANCE}
+            </p>
+          </div>
+          <span style={{ fontSize: 12, color: tokens.textDim }}>◎</span>
+        </div>
+
+        {/* Quick stats: 3 pills */}
+        <div style={{ display: 'flex', gap: 8 }}>
+          <div
+            style={{
+              flex: 1,
+              background: tokens.successSoft,
+              borderRadius: 10,
+              padding: '8px 10px',
+            }}
+          >
+            <p
+              style={{
+                margin: '0 0 2px',
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: '0.07em',
+                textTransform: 'uppercase',
+                color: tokens.success,
+              }}
+            >
+              Ingresos
+            </p>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 13,
+                fontWeight: 700,
+                color: tokens.success,
+              }}
+            >
+              +$850k
+            </p>
+          </div>
+          <div
+            style={{
+              flex: 1,
+              background: tokens.warningSoft,
+              borderRadius: 10,
+              padding: '8px 10px',
+            }}
+          >
+            <p
+              style={{
+                margin: '0 0 2px',
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: '0.07em',
+                textTransform: 'uppercase',
+                color: tokens.warning,
+              }}
+            >
+              Gastos
+            </p>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 13,
+                fontWeight: 700,
+                color: tokens.warning,
+              }}
+            >
+              −$62k
+            </p>
+          </div>
+          <div
+            style={{
+              flex: 1,
+              background: 'rgba(33,120,168,0.07)',
+              borderRadius: 10,
+              padding: '8px 10px',
+            }}
+          >
+            <p
+              style={{
+                margin: '0 0 2px',
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: '0.07em',
+                textTransform: 'uppercase',
+                color: tokens.primary,
+              }}
+            >
+              Tarjetas
+            </p>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 13,
+                fontWeight: 700,
+                color: tokens.primary,
+              }}
+            >
+              $260k
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* ── DISPONIBLE + COMPROMISOS (fila compacta) ─────── */}
+      <div
+        style={{
+          margin: '0 12px 12px',
+          display: 'flex',
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            flex: 1,
+            background: tokens.bgSecondary,
+            border: `1px solid ${tokens.separator}`,
+            borderRadius: 12,
+            padding: '10px 12px',
+          }}
+        >
+          <p
+            style={{
+              margin: '0 0 2px',
+              fontSize: 11,
+              color: tokens.textDim,
+            }}
+          >
+            Disponible real
+          </p>
+          <p
+            style={{
+              margin: 0,
+              fontSize: 15,
+              fontWeight: 700,
+              color: tokens.success,
+            }}
+          >
+            {MOCK_DISPONIBLE}
+          </p>
+        </div>
+        <div
+          style={{
+            flex: 1,
+            background: tokens.bgSecondary,
+            border: `1px solid rgba(184,74,18,0.12)`,
+            borderRadius: 12,
+            padding: '10px 12px',
+          }}
+        >
+          <p
+            style={{
+              margin: '0 0 2px',
+              fontSize: 11,
+              color: tokens.textDim,
+            }}
+          >
+            Compromisos
+          </p>
+          <p
+            style={{
+              margin: 0,
+              fontSize: 15,
+              fontWeight: 700,
+              color: tokens.warning,
+            }}
+          >
+            {MOCK_COMPROMISOS}
+          </p>
+        </div>
+      </div>
+
+      {/* ── SECTION HEADER ───────────────────────────────── */}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '0 16px 8px',
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.09em',
+            textTransform: 'uppercase',
+            color: tokens.textDim,
+          }}
+        >
+          Recientes
+        </span>
+        <span style={{ fontSize: 12, color: tokens.primary, fontWeight: 600 }}>
+          Ver todos →
+        </span>
+      </div>
+
+      {/* ── MOVEMENTS LIST (densa) ───────────────────────── */}
+      <div style={{ padding: '0 12px' }}>
+        {MOCK_MOVEMENTS.map((mv, i) => (
+          <div
+            key={i}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              padding: '9px 4px',
+              borderBottom:
+                i < MOCK_MOVEMENTS.length - 1
+                  ? `1px solid ${tokens.separator}`
+                  : 'none',
+            }}
+          >
+            <CategoryDot color={mv.color} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: tokens.textPrimary,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {mv.label}
+              </p>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: 11,
+                  color: tokens.textDim,
+                }}
+              >
+                {mv.cat} · {mv.date}
+              </p>
+            </div>
+            <span
+              style={{
+                fontSize: 13,
+                fontWeight: 700,
+                color: mv.amount.startsWith('+') ? tokens.success : tokens.textPrimary,
+                flexShrink: 0,
+              }}
+            >
+              {mv.amount}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* ── BOTTOM ZONE ──────────────────────────────────── */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          background: tokens.bgPrimary,
+          borderTop: `1px solid ${tokens.separator}`,
+          paddingBottom: 20,
+        }}
+      >
+        {/* SmartInput como barra persistente */}
+        <div style={{ padding: '8px 12px 4px' }}>
+          <div
+            style={{
+              background: tokens.bgTertiary,
+              borderRadius: 12,
+              padding: '10px 14px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+            }}
+          >
+            <span style={{ fontSize: 13, color: tokens.textDim, flex: 1 }}>
+              Agregar movimiento…
+            </span>
+            <span
+              style={{
+                fontSize: 12,
+                fontWeight: 700,
+                color: tokens.primary,
+                background: tokens.primarySoft,
+                padding: '3px 8px',
+                borderRadius: 6,
+              }}
+            >
+              + Agregar
+            </span>
+          </div>
+        </div>
+
+        {/* TabBar plana con dot indicador */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-around',
+            padding: '6px 20px 0',
+          }}
+        >
+          {[
+            { icon: '⌂', label: 'Home', active: true },
+            { icon: '≡', label: 'Movimientos', active: false },
+            { icon: '◷', label: 'Análisis', active: false },
+          ].map((tab) => (
+            <div
+              key={tab.label}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 3,
+                padding: '4px 12px',
+                position: 'relative',
+              }}
+            >
+              {/* Active dot */}
+              {tab.active && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    width: 4,
+                    height: 4,
+                    borderRadius: '50%',
+                    background: tokens.primary,
+                  }}
+                />
+              )}
+              <span
+                style={{
+                  fontSize: 19,
+                  color: tab.active ? tokens.primary : tokens.textDim,
+                  lineHeight: 1,
+                }}
+              >
+                {tab.icon}
+              </span>
+              <span
+                style={{
+                  fontSize: 10,
+                  fontWeight: tab.active ? 700 : 400,
+                  color: tab.active ? tokens.primary : tokens.textDim,
+                }}
+              >
+                {tab.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </PhoneFrame>
+  )
+}

--- a/components/_exploration/VariantC.tsx
+++ b/components/_exploration/VariantC.tsx
@@ -1,0 +1,405 @@
+// THROWAWAY — Variante C: Híbrida Sobria con Foco en Acción
+// No modifica lógica ni componentes de producción.
+
+import {
+  PhoneFrame,
+  Avatar,
+  PlusBtn,
+  CategoryDot,
+  MOCK_BALANCE,
+  MOCK_DISPONIBLE,
+  MOCK_COMPROMISOS,
+  MOCK_MOVEMENTS,
+  tokens,
+} from './shared'
+
+export function VariantC() {
+  return (
+    <PhoneFrame
+      label="Híbrida Sobria · Foco en Acción"
+      tag="Variante C"
+      tagColor="#4A1A6A"
+    >
+      {/* Safe area top */}
+      <div style={{ paddingTop: 16 }} />
+
+      {/* ── HEADER ────────────────────────────────────────── */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 20px 16px',
+        }}
+      >
+        <Avatar />
+        <span
+          style={{
+            fontSize: 14,
+            fontWeight: 600,
+            color: tokens.textSecondary,
+          }}
+        >
+          Mayo 2026
+        </span>
+        <PlusBtn />
+      </div>
+
+      {/* ── HERO CARD: balance prominente, elevado ────────── */}
+      <div
+        style={{
+          margin: '0 16px',
+          borderRadius: 20,
+          background: '#FFFFFF',
+          boxShadow: '0 4px 16px rgba(13,24,41,0.09)',
+          padding: '18px 20px 14px',
+          marginBottom: 8,
+        }}
+      >
+        {/* Label */}
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.09em',
+            textTransform: 'uppercase',
+            color: tokens.textDim,
+          }}
+        >
+          Saldo Vivo
+        </span>
+
+        {/* Hero number + eye */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            margin: '6px 0 6px',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 38,
+              fontWeight: 800,
+              color: tokens.textPrimary,
+              letterSpacing: '-0.03em',
+              lineHeight: 1.1,
+            }}
+          >
+            {MOCK_BALANCE}
+          </div>
+          <span style={{ fontSize: 14, color: tokens.textDim, marginTop: 4 }}>◎</span>
+        </div>
+
+        {/* ARS / USD inline */}
+        <div
+          style={{
+            display: 'flex',
+            gap: 6,
+            marginBottom: 14,
+          }}
+        >
+          <span
+            style={{ fontSize: 11, fontWeight: 600, color: tokens.primary }}
+          >
+            ARS
+          </span>
+          <span style={{ fontSize: 11, color: tokens.textDim }}>1.240.500</span>
+          <span style={{ fontSize: 11, color: tokens.separator }}>|</span>
+          <span
+            style={{ fontSize: 11, fontWeight: 600, color: tokens.primary }}
+          >
+            USD
+          </span>
+          <span style={{ fontSize: 11, color: tokens.textDim }}>1.240</span>
+        </div>
+
+        {/* Divider */}
+        <div
+          style={{
+            height: 1,
+            background: tokens.separator,
+            marginBottom: 12,
+          }}
+        />
+
+        {/* Disponible Real row */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: '50%',
+                background: 'rgba(33,120,168,0.08)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 16,
+              }}
+            >
+              👛
+            </div>
+            <div>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: 13,
+                  fontWeight: 500,
+                  color: tokens.textSecondary,
+                }}
+              >
+                Disponible real
+              </p>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: 11,
+                  color: tokens.textDim,
+                }}
+              >
+                Descuenta deuda y tarjeta
+              </p>
+            </div>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <span
+              style={{
+                fontSize: 15,
+                fontWeight: 700,
+                color: tokens.textPrimary,
+              }}
+            >
+              {MOCK_DISPONIBLE}
+            </span>
+            <span style={{ fontSize: 11, color: tokens.textDim }}>›</span>
+          </div>
+        </div>
+      </div>
+
+      {/* ── COMPROMISOS: barra debajo del card ───────────── */}
+      <div
+        style={{
+          margin: '0 16px 16px',
+          background: tokens.bgSecondary,
+          borderRadius: '0 0 12px 12px',
+          padding: '10px 14px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          borderBottom: `1px solid ${tokens.separator}`,
+          borderLeft: `1px solid ${tokens.separator}`,
+          borderRight: `1px solid ${tokens.separator}`,
+        }}
+      >
+        <span style={{ fontSize: 12, color: tokens.textSecondary }}>
+          Compromisos tarjetas
+        </span>
+        <span
+          style={{
+            fontSize: 13,
+            fontWeight: 700,
+            color: tokens.warning,
+          }}
+        >
+          {MOCK_COMPROMISOS} ›
+        </span>
+      </div>
+
+      {/* ── SECTION HEADER ───────────────────────────────── */}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '0 20px 8px',
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.09em',
+            textTransform: 'uppercase',
+            color: tokens.textDim,
+          }}
+        >
+          Últimos movimientos
+        </span>
+        <span style={{ fontSize: 12, color: tokens.primary, fontWeight: 600 }}>
+          Ver todos →
+        </span>
+      </div>
+
+      {/* ── MOVEMENTS LIST ───────────────────────────────── */}
+      <div style={{ padding: '0 16px' }}>
+        {MOCK_MOVEMENTS.map((mv, i) => (
+          <div
+            key={i}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              padding: '11px 4px',
+              borderBottom:
+                i < MOCK_MOVEMENTS.length - 1
+                  ? `1px solid ${tokens.separator}`
+                  : 'none',
+            }}
+          >
+            <CategoryDot color={mv.color} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: 14,
+                  fontWeight: 600,
+                  color: tokens.textPrimary,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {mv.label}
+              </p>
+              <p
+                style={{
+                  margin: '2px 0 0',
+                  fontSize: 12,
+                  color: tokens.textDim,
+                }}
+              >
+                {mv.cat} · {mv.date}
+              </p>
+            </div>
+            <span
+              style={{
+                fontSize: 14,
+                fontWeight: 700,
+                color: mv.amount.startsWith('+') ? tokens.success : tokens.textPrimary,
+                flexShrink: 0,
+              }}
+            >
+              {mv.amount}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* ── BOTTOM ZONE ──────────────────────────────────── */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          background: 'rgba(255,255,255,0.97)',
+          backdropFilter: 'blur(20px)',
+          paddingBottom: 20,
+        }}
+      >
+        {/* SmartInput: glass pill con separación visual */}
+        <div style={{ padding: '10px 16px 6px' }}>
+          <div
+            style={{
+              background: 'rgba(190,225,248,0.28)',
+              border: '1px solid rgba(255,255,255,0.90)',
+              borderRadius: 16,
+              padding: '11px 14px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+            }}
+          >
+            <span style={{ fontSize: 14, color: tokens.textDim, flex: 1 }}>
+              ¿Qué gastaste?
+            </span>
+            <div
+              style={{
+                width: 26,
+                height: 26,
+                borderRadius: '50%',
+                background: tokens.primary,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#fff',
+                fontSize: 14,
+                flexShrink: 0,
+              }}
+            >
+              ✦
+            </div>
+          </div>
+        </div>
+
+        {/* TabBar: indicador top-bar sobre activo (patrón iOS nativo) */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-around',
+            padding: '6px 20px 0',
+          }}
+        >
+          {[
+            { icon: '⌂', label: 'Home', active: true },
+            { icon: '≡', label: 'Movimientos', active: false },
+            { icon: '◷', label: 'Análisis', active: false },
+          ].map((tab) => (
+            <div
+              key={tab.label}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 4,
+                padding: '2px 12px 4px',
+                position: 'relative',
+              }}
+            >
+              {/* Top bar indicador */}
+              <div
+                style={{
+                  position: 'absolute',
+                  top: -6,
+                  left: '50%',
+                  transform: 'translateX(-50%)',
+                  width: tab.active ? 28 : 0,
+                  height: 2,
+                  borderRadius: 1,
+                  background: tokens.primary,
+                  transition: 'width 0.2s ease',
+                }}
+              />
+              <span
+                style={{
+                  fontSize: 19,
+                  color: tab.active ? tokens.primary : tokens.textDim,
+                  lineHeight: 1,
+                }}
+              >
+                {tab.icon}
+              </span>
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: tab.active ? 700 : 400,
+                  color: tab.active ? tokens.primary : tokens.textDim,
+                }}
+              >
+                {tab.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </PhoneFrame>
+  )
+}

--- a/components/_exploration/shared.tsx
+++ b/components/_exploration/shared.tsx
@@ -1,0 +1,201 @@
+// THROWAWAY — primitivas compartidas para mockups de exploración
+import type { CSSProperties, ReactNode } from 'react'
+
+export const MOCK_BALANCE = '$1.240.500'
+export const MOCK_BALANCE_USD = 'USD 1.240'
+export const MOCK_DISPONIBLE = '$980.200'
+export const MOCK_COMPROMISOS = '$260.300'
+
+export const MOCK_MOVEMENTS = [
+  { label: 'Mercado Libre', cat: 'Compras', amount: '−$18.400', date: 'Hoy', color: '#B84A12' },
+  { label: 'Sueldo Mayo', cat: 'Ingreso', amount: '+$850.000', date: 'Ayer', color: '#1A7A42' },
+  { label: 'UberEats', cat: 'Delivery', amount: '−$9.200', date: 'Ayer', color: '#B84A12' },
+  { label: 'Transf. Naranja', cat: 'Tarjeta', amount: '−$35.000', date: 'Mié', color: '#2178A8' },
+]
+
+interface PhoneFrameProps {
+  label: string
+  tag: string
+  tagColor: string
+  children: ReactNode
+  accentColor?: string
+}
+
+export function PhoneFrame({ label, tag, tagColor, children }: PhoneFrameProps) {
+  return (
+    <div>
+      <div style={{ marginBottom: 12 }}>
+        <span
+          style={{
+            display: 'inline-block',
+            background: tagColor,
+            color: '#fff',
+            borderRadius: 6,
+            padding: '3px 10px',
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            marginBottom: 6,
+          }}
+        >
+          {tag}
+        </span>
+        <p
+          style={{
+            margin: 0,
+            fontSize: 16,
+            fontWeight: 700,
+            color: '#1A2B3C',
+          }}
+        >
+          {label}
+        </p>
+      </div>
+
+      {/* Phone shell */}
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 375,
+          margin: '0 auto',
+          borderRadius: 44,
+          background: '#111',
+          padding: '8px',
+          boxShadow: '0 24px 60px rgba(0,0,0,0.30), 0 4px 12px rgba(0,0,0,0.15)',
+        }}
+      >
+        {/* Dynamic Island */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            paddingTop: 10,
+            paddingBottom: 4,
+          }}
+        >
+          <div
+            style={{
+              width: 120,
+              height: 34,
+              borderRadius: 20,
+              background: '#000',
+            }}
+          />
+        </div>
+        {/* Screen */}
+        <div
+          style={{
+            borderRadius: 36,
+            overflow: 'hidden',
+            background: '#FFFFFF',
+            position: 'relative',
+            minHeight: 720,
+          }}
+        >
+          {children}
+        </div>
+        {/* Home indicator */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            paddingTop: 6,
+            paddingBottom: 8,
+          }}
+        >
+          <div
+            style={{ width: 120, height: 4, borderRadius: 2, background: '#444' }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const tokens = {
+  bgPrimary: '#FFFFFF',
+  bgSecondary: '#F8FBFD',
+  bgTertiary: '#EEF4F8',
+  primary: '#2178A8',
+  primarySoft: 'rgba(33,120,168,0.09)',
+  success: '#1A7A42',
+  successSoft: 'rgba(26,122,66,0.10)',
+  warning: '#B84A12',
+  warningSoft: 'rgba(184,74,18,0.10)',
+  textPrimary: '#0D1829',
+  textSecondary: '#4A6070',
+  textDim: '#5C7A8A',
+  separator: 'rgba(33,120,168,0.07)',
+  navBg: 'rgba(255,255,255,0.97)',
+}
+
+export function Avatar({ size = 34 }: { size?: number }) {
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: tokens.primary,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: '#fff',
+        fontSize: size * 0.38,
+        fontWeight: 700,
+        flexShrink: 0,
+      }}
+    >
+      F
+    </div>
+  )
+}
+
+export function PlusBtn({ size = 34 }: { size?: number }) {
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: tokens.primary,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: '#fff',
+        fontSize: size * 0.5,
+        fontWeight: 300,
+        flexShrink: 0,
+      }}
+    >
+      +
+    </div>
+  )
+}
+
+export function CategoryDot({ color }: { color: string }) {
+  return (
+    <div
+      style={{
+        width: 32,
+        height: 32,
+        borderRadius: '50%',
+        background: color + '18',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+      }}
+    >
+      <div
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          background: color,
+        }}
+      />
+    </div>
+  )
+}

--- a/docs/mobile-ui-exploration-2026-05.md
+++ b/docs/mobile-ui-exploration-2026-05.md
@@ -1,0 +1,360 @@
+# Gota — Mobile UI Exploration
+**Fecha:** 2026-05-25  
+**Etapa:** Exploración + Refinement (input para Claude Design)  
+**Alcance:** Home + TabBar — solo capa visual, sin tocar lógica
+
+---
+
+## 1. Diagnóstico del estado actual
+
+### Home — estructura actual
+
+```
+pt-safe
+├── HEADER ROW (px-4, pt-5)
+│   ├── Avatar circular [izquierda] → abre CuentaSheet
+│   └── HomePlusButton [derecha] → abre modal de acciones
+│
+├── PendingSharedReceiptBanner (condicional)
+│
+├── SaldoVivo (sin card, directo sobre fondo)
+│   ├── Label "Saldo Vivo" + eye toggle
+│   ├── Hero number (type-hero 40px/800)
+│   ├── ARS | USD breakdown (type-meta)
+│   └── "Disponible real" row (border-t separator + icon 44px + monto)
+│
+├── CommitmentsSummary (condicional, border-t separator)
+│   ├── Icon circle + label + monto total
+│   └── Progress bar + leyenda A pagar / En curso
+│
+├── RecurringIncomeBanner (condicional)
+├── InstrumentosCard (FF_INSTRUMENTS flag)
+├── SubscriptionReviewBanner (condicional)
+│
+└── Ultimos5 (lista de movimientos recientes)
+    └── → "Ver todos" → /movimientos
+
+FIXED BOTTOM (BottomZone)
+├── SmartInput (Gemini, expansible)
+└── TabBar integrado (solo en Home, cuando SmartInput está cerrado)
+```
+
+### TabBar — comportamiento actual
+
+- **En Home (`/`):** integrado dentro de `BottomZone`, después de SmartInput.
+- **En otras rutas:** `fixed bottom-0` con `backdrop-filter: blur(16px)` y `border-t`.
+- **Active state:** icono `weight="bold"` + texto `text-primary`. Sin pill, sin indicator.
+- **3 tabs:** Home, Movimientos, Análisis.
+- **Labels:** siempre visibles, 12px, `whitespace-nowrap`.
+
+---
+
+## 2. Problemas identificados
+
+### Jerarquía visual
+
+| # | Problema | Impacto |
+|---|----------|---------|
+| P1 | **Hero sin framing**: el número principal (SaldoVivo) flota sobre blanco sin ningún contenedor visual. La métrica más importante no tiene peso visual. | Alto |
+| P2 | **Mismo peso visual en todas las secciones**: CommitmentsSummary, Ultimos5 y banners opcionales están todos al mismo "nivel" visual, solo separados por `border-t`. | Alto |
+| P3 | **Sin contexto de mes en Home**: `DashboardHeader` no está integrado en `DashboardShell`. El usuario no sabe en qué mes está sin scrollear. | Medio |
+| P4 | **BottomZone opaca el propósito del SmartInput**: en estado colapsado, el SmartInput no comunica claramente que es un campo de entrada. Parece un área gris de navegación. | Medio |
+| P5 | **Active state de TabBar demasiado minimal**: solo cambio de color y peso de fuente. No hay indicador geométrico (pill, underline, top bar). | Medio |
+| P6 | **Inconsistencia visual Home vs. otras rutas**: en Home el TabBar está "dentro" del contenido; en otras rutas está "fuera" como fixed nav. Este cambio puede producir sensación de salto. | Bajo |
+
+### Percepción nativa
+
+- El layout es correcto para web: columna full-width, `max-w-md`, padding horizontal uniforme.  
+- Para una PWA que debe sentirse **app nativa**, falta: jerarquía de superficies (elevation), identificación de zonas (header / content / toolbar), y micro-pattern de activación de tabs.
+- El Hero necesita "contener" su contenido. En apps nativas premium (Nubank, Revolut, N26) el saldo siempre vive dentro de una superficie diferenciada.
+
+### Densidad
+
+- Con datos normales (SaldoVivo + Compromisos + Ultimos5), el scroll empieza después del hero. Bien.
+- Cuando hay banners opcionales acumulados (RecurringIncome + Subscriptions + Instruments), el Home puede verse muy cargado. No hay prioridad visual entre ellos.
+
+---
+
+## 3. Propuestas de dirección visual
+
+> Los artefactos visuales están en `/components/_exploration/` y en la ruta `/ui-exploration` (solo dev).
+
+---
+
+### Variante A — Fintech Calma / Premium
+
+**Postura:** "Respirá. El número es lo único que importa ahora."
+
+#### Layout
+```
+Header: Avatar | Mes pill (center) | Plus
+Hero card: rounded-22, gradiente sutil azul (surface-glass-lite)
+  └── Label · Hero number · Pills ARS/USD · divider
+      └── Disponible + Compromisos en fila dentro del mismo card
+           └── Progress bar 4px (warning + primary)
+Sección "Últimos movimientos" (label uppercase + "Ver todos")
+Lista de movimientos (comfortable density, 11px+ row height)
+
+Bottom:
+  SmartInput (glass pill, prominente, con icono ✦ Gemini)
+  TabBar (pills rellenas en activo, como iOS)
+```
+
+#### Jerarquía
+1. Hero card (nivel 1) — toda la info financiera del mes
+2. Lista de movimientos (nivel 2) — actividad
+3. BottomZone (toolbar) — acción + navegación
+
+#### TabBar
+- Pill background (`primarySoft`) alrededor del item activo.
+- Labels visibles, 11px.
+- Altura efectiva ~52px de touch area.
+
+#### Acciones rápidas
+- Plus en el header (igual que ahora).
+- SmartInput como entry point principal para gastos.
+
+#### Hero
+- Card con `border-radius: 22px`, gradiente `rgba(33,120,168,0.07) → rgba(27,126,158,0.04)`, `border: 1px solid rgba(33,120,168,0.10)`.
+- Disponible Real y Compromisos colapsados dentro del mismo card (no como elementos separados).
+- Ahorra ~40px de altura vertical, simplifica el scroll.
+
+#### Densidad
+Baja-media. Una zona principal muy dominante, todo lo demás subordinado.
+
+#### Pros
+- Más premium, más "app bancaria de confianza".
+- Hero unificado reduce scroll para ver el estado completo.
+- El contexto financiero (disponible + compromisos) está siempre visible sin scroll.
+
+#### Contras
+- La card puede sentirse "grande" en iPhones SE o pantallas <375px.
+- Menos datos a primera vista puede frustrar usuarios power.
+- El pill de tab activo puede entrar en conflicto visual con el SmartInput si no se calibra bien la altura del BottomZone.
+
+---
+
+### Variante B — Nativa Operativa / Densa
+
+**Postura:** "Soy una herramienta. Dame todo sin que tenga que scrollear."
+
+#### Layout
+```
+Header: Avatar | "Mayo 2026" (centered, bold) | Plus
+Hero compacto: card bg-secondary, border, padding apretado
+  └── Label + Hero (30px/800) + eye toggle
+      └── Fila de 3 chips: Ingresos / Gastos / Tarjetas
+Fila de 2 cards compactas: Disponible Real | Compromisos
+Section label "Recientes"
+Lista densa (rows de 9px vertical padding, texto 13px)
+Bottom: SmartInput texto + "Agregar" button · TabBar con dot indicador
+```
+
+#### Jerarquía
+1. Stats compactos (balance + métricas mes) — nivel 1
+2. Disponible + Compromisos lado a lado — nivel 2
+3. Lista densa — nivel 3
+
+#### TabBar
+- Sin fill/pill en activo.
+- Dot de 4px sobre el icono activo (arriba).
+- Sin cambio de fondo.
+
+#### Acciones rápidas
+- SmartInput colapsado como "barra de texto" con botón "+ Agregar" visible.
+- El CTA es más explícito que en las otras variantes.
+
+#### Hero
+- Sin gradiente. Card plana `bg-secondary` con border sutil.
+- Hero number más pequeño (30px vs 40px).
+- Los chips de stats (Ingresos / Gastos / Tarjetas) reemplazan al ARS/USD breakdown para dar más contexto operativo.
+
+#### Densidad
+Alta. Más info visible sin scroll en pantallas de tamaño estándar.
+
+#### Pros
+- Power users ven más sin scroll.
+- El SmartInput visible como barra es más claro en su función.
+- Los stats (ingresos/gastos del mes) son más relevantes que el breakdown ARS/USD para usuarios operativos.
+
+#### Contras
+- Se pierde la elegancia del hero dominante.
+- Los chips de stats requieren datos (si el mes está vacío, lucen pobres).
+- Puede sentirse "aglomerado" con datos reales variados.
+- Rompe el principio de diseño actual: "SaldoVivo y listas sobre fondo directo, menos stack de cards".
+
+---
+
+### Variante C — Híbrida Sobria con Foco en Acción ⭐ (Recomendada)
+
+**Postura:** "El estado está claro. La acción está a mano."
+
+#### Layout
+```
+Header: Avatar | "Mayo 2026" (text, no pill) | Plus
+Hero card: bg-white, shadow-md (surface-module elevation)
+  └── Label · Hero (38px/800) · ARS|USD inline
+      └── border-t · Disponible Real row (icon + texto + monto ›)
+Compromisos: barra anclada debajo del card, bg-secondary (patrón "extensión" del card)
+Section label "Últimos movimientos"
+Lista (comfortable density)
+
+Bottom:
+  SmartInput (glass pill, ✦ icono Gemini)
+  TabBar con top-bar indicator (2px, 28px width sobre activo)
+```
+
+#### Jerarquía
+1. Hero card elevado (shadow) + compromisos colgante — zona financiera
+2. Lista de movimientos — zona de actividad
+3. BottomZone (glass) — zona de acción + navegación
+
+#### TabBar
+- Thin top bar (2px, 28px) sobre el icono del tab activo.
+- Patrón tomado de iOS nativo (tab bar indicator en aplicaciones como Wallet).
+- Labels visibles, 11px.
+- Sin pill fill en activo: más sobrio.
+
+#### Acciones rápidas
+- Plus en header (igual que ahora).
+- SmartInput como glass pill: reconocible, con icono ✦ Gemini visible.
+
+#### Hero
+- `shadow-md` (`0 4px 12px rgba(13,24,41,0.08)`) sobre white: elevation sin color.
+- Compromisos se "cuelga" visualmente del card con `border-radius: 0 0 12px 12px` y `bg-secondary`.
+- Menos padding que Variante A pero más respiración que Variante B.
+
+#### Densidad
+Media. Equilibrio entre información y legibilidad.
+
+#### Pros
+- El elevation del hero card es el movimiento más impactante y requiere el cambio más mínimo.
+- El top-bar de tab activo es el indicador más nativo sin tocar la estructura actual.
+- Los compromisos "colgados" del card es un truco visual que unifica la zona financiera sin rediseñar components.
+- Mantiene el principio del design system: `surface-module` para el hero.
+- El SmartInput ya usa `surface-glass`, que en colapsado con el ✦ Gemini sería reconocible.
+
+#### Contras
+- El contexto del mes requiere un cambio pequeño (agregar el texto del mes en el header de `DashboardShell`).
+- La "cola" de compromisos colgada del card es un patrón nuevo que hay que definir bien en tokens.
+
+---
+
+## 4. Recomendación final
+
+### Dirección: Variante C (Híbrida Sobria) con elementos de Variante A
+
+**Por qué C:**
+
+1. **Costo de implementación bajo.** El cambio principal es agregar `box-shadow: var(--shadow-md)` al contenedor de SaldoVivo. El resto son ajustes de tokens, no refactors.
+
+2. **Respeta el design system vigente.** `surface-module` ya existe como token. Solo hay que aplicarlo donde más importa: el hero.
+
+3. **TabBar top-bar indicator es el cambio más nativo con menor riesgo.** No toca el HTML ni la lógica, solo CSS. El `border-top: 2px solid var(--color-primary)` sobre el item activo ya es suficiente.
+
+4. **La "cola" de compromisos unifica la zona financiera** sin crear un nuevo componente. Es solo un reajuste del border-radius y background de `CommitmentsSummary`.
+
+5. **Preserva el patrón BottomZone + SmartInput integrado**, que es el diferencial más inteligente de la app. Solo refina la presentación.
+
+**Tomado de A:**
+- Agregar el mes al header de DashboardShell (texto simple, no pill).
+- El SmartInput con icono ✦ visible (ya tiene espacio para un placeholder más visible).
+
+**Desechar de B:**
+- Los chips de Ingresos/Gastos/Tarjetas son un cambio de modelo de datos en el hero, no solo visual. Fuera del scope.
+
+---
+
+## 5. Brief para Claude Design
+
+### Título
+**Gota Mobile — Shell refinement v1**
+
+### Objetivo
+Hacer que el Home se sienta app nativa premium sin cambiar la estructura de componentes ni la lógica.
+
+### Cambios concretos a diseñar
+
+#### 1. Hero card con elevation
+- Envolver el contenido de `SaldoVivo` (y su componente adjunto `CommitmentsSummary`) en una superficie elevada.
+- Token: `surface-module` (`background: #FFFFFF; box-shadow: 0 4px 12px rgba(13,24,41,0.08)`)
+- Radius: `radius-card-lg` (22px)
+- Padding: 20px horizontal, 18px vertical
+- El `CommitmentsSummary` se convierte en la "sección inferior" del mismo card: background `bg-secondary`, radius `0 0 22px 22px`, separado del cuerpo por `border-t: separator`.
+
+#### 2. Header con contexto de mes
+- Agregar el mes actual como texto centrado en el header de `DashboardShell`.
+- Texto: 14px / 600 / `text-secondary`
+- No requiere month selector aquí (ya está en DashboardHeader en otras rutas)
+
+#### 3. TabBar active indicator
+- Reemplazar el bold weight + color por: `border-top: 2px solid var(--color-primary)` sobre el item activo.
+- O pill background `primarySoft` (Variante A) — decidir con el diseñador.
+- Altura de touch area: mínimo 44px.
+
+#### 4. SmartInput: placeholder más visible
+- Placeholder: `"¿Qué gastaste?"` (más conversacional que el actual, si es que está vacío)
+- Icono ✦ o similar como indicador Gemini en el lado derecho (ya hay espacio)
+
+#### 5. Zona de movimientos: section header
+- Agregar label `"Últimos movimientos"` + link `"Ver todos →"` antes de `Ultimos5`
+- Clarifica la zona de actividad vs. la zona financiera del hero
+
+### Tokens de referencia
+- `surface-module`: `background: #FFFFFF; box-shadow: 0 4px 12px rgba(13,24,41,0.08)`
+- `shadow-md`: `0 4px 12px rgba(13,24,41,0.08)`
+- `separator`: `rgba(33,120,168,0.07)`
+- `primary`: `#2178A8`
+- `primarySoft`: `rgba(33,120,168,0.09)`
+- `radius-card-lg`: `22px`
+
+### Lo que NO cambiar
+- Lógica de datos (queries, cálculos, APIs)
+- Estructura de componentes (no fusionar SaldoVivo y CommitmentsSummary en código)
+- Flujo de SmartInput (funciona bien)
+- 3 tabs (correctos)
+- BottomZone integrada en Home (patrón inteligente, mantener)
+- Tokens de color existentes
+
+---
+
+## 6. Artefactos de exploración
+
+- **Mockups:** `/ui-exploration` (ruta dev, throwaway)
+- **Componentes:** `components/_exploration/` (throwaway, no importar en producción)
+- **Este documento:** `docs/mobile-ui-exploration-2026-05.md`
+
+---
+
+## 7. Decisiones tomadas en esta etapa
+
+| Decisión | Razonamiento |
+|----------|-------------|
+| Mantener 3 tabs | Correcto. Más tabs fragmentaría la app. |
+| Mantener BottomZone integrada en Home | Diferenciador inteligente. No tocar. |
+| Hero con elevation, no con color | Colores ya están en uso semántico. Elevation es el lever correcto. |
+| Top-bar indicator en TabBar | Patrón más nativo que pill fill. Menor riesgo visual. |
+| No mover `+` al centro del TabBar | El patrón de FAB central rompe la consistencia con otras rutas. |
+| No agregar stats de mes en hero | Requiere datos nuevos. Fuera del scope visual. |
+
+---
+
+## 8. Dudas abiertas para resolver con diseñador
+
+1. **TabBar active state:** ¿top-bar indicator (C) o pill background (A)? Ambos son válidos, pero no mezclar.
+2. **CommitmentsSummary como "cola" del hero card:** ¿siempre visible aunque sean $0? ¿O se colapsa? Actualmente aparece solo si hay compromisos.
+3. **Contexto de mes en Home:** ¿texto plano en header o pill tappable? Si es tappable, ¿qué hace? (Actualmente la navegación de mes vive en otras rutas.)
+4. **SmartInput collapsed state:** ¿El placeholder `"¿Qué gastaste?"` es suficiente CTA? ¿O necesita un label tipo `"SMART INPUT"` / `"IA"` visible?
+5. **Banners opcionales** (RecurringIncome, Subscriptions): cuando hay 2+ banners visibles, el Home se fragmenta. ¿Consolidar en un único "Alerts/Pendiente" card?
+6. **Dark mode:** ¿Es un objetivo para esta etapa? El design system es light-only. Si se va a explorar dark en el futuro, los shadows de `surface-module` no funcionan igual sobre fondos oscuros.
+
+---
+
+## 9. Recomendaciones para la siguiente etapa (Claude Design)
+
+1. **Empezar por el hero card** — es el cambio de mayor impacto visual y menor riesgo técnico.
+2. **Diseñar 2 estados del hero:** con compromisos visibles y sin compromisos, para validar el patrón "cola colgante".
+3. **Definir el TabBar active state** (top-bar vs. pill) antes de tocar cualquier otra cosa. Una vez definido, aplica a las 3 rutas con TabBar.
+4. **No diseñar el SmartInput** en esta etapa — está en producción y funciona. Solo ajustar el placeholder si el diseñador lo ve necesario.
+5. **Hacer un mock del Home con banners acumulados** (2-3 banners opcionales visibles) para detectar si se necesita una estrategia de "alert stack" unificada.
+6. **Prototipar en 375px** (iPhone SE 3 / iPhone 14 estándar). El hero card no debe cortar en pantallas de < 390px de altura visible.


### PR DESCRIPTION
Throwaway artefacts only. No production logic touched.

- docs/mobile-ui-exploration-2026-05.md: full diagnosis, 3 variant proposals,
  recommendation (Variant C), brief for Claude Design, open questions
- app/(exploration)/ui-exploration/page.tsx: dev-only route at /ui-exploration
- components/_exploration/: VariantA (calma/premium), VariantB (operativa/densa),
  VariantC (sobria/acción) as static phone-frame mockups

https://claude.ai/code/session_01RGWhaRU6J2utkWn16Q6kXm