### PR TITLE
Incluir pagos de tarjeta en cálculo de egresos mensuales de Insights

### DIFF
--- a/app/api/analytics-data/route.ts
+++ b/app/api/analytics-data/route.ts
@@ -6,6 +6,7 @@ import type {
 import { addMonths, getCurrentMonth } from '@/lib/dates'
 import { isMissingCardCycleAmountsTableError } from '@/lib/card-cycle-amounts'
 import {
+  isApplicableCardPayment,
   isCreditAccruedExpense,
   isPerceivedExpense,
 } from '@/lib/movement-classification'
@@ -65,7 +66,7 @@ function buildMonthlySeries(params: {
     const point = monthMap.get(month)
     if (!point) continue
 
-    const perceived = isPerceivedExpense(expense)
+    const perceived = isPerceivedExpense(expense) || isApplicableCardPayment(expense)
     const accrued = isCreditAccruedExpense(expense)
     const day = getMonthDay(expense.date)
 
@@ -215,10 +216,16 @@ export async function GET(request: Request) {
   const ingresoMes = (incomeEntries ?? []).reduce((sum, entry) => sum + entry.amount, 0)
   const earliestDataMonth = oldestExpense?.date?.substring(0, 7) ?? null
   const rawExpenses = ((rawExpensesData ?? []) as Expense[]).filter(
-    (expense) => isPerceivedExpense(expense) || isCreditAccruedExpense(expense),
+    (expense) =>
+      isPerceivedExpense(expense) ||
+      isApplicableCardPayment(expense) ||
+      isCreditAccruedExpense(expense),
   )
   const historicalExpenses = ((historicalExpensesData ?? []) as Expense[]).filter(
-    (expense) => isPerceivedExpense(expense) || isCreditAccruedExpense(expense),
+    (expense) =>
+      isPerceivedExpense(expense) ||
+      isApplicableCardPayment(expense) ||
+      isCreditAccruedExpense(expense),
   )
   const comparisonDay = selectedMonth === currentMonth ? new Date().getDate() : null
   const monthlySeries = buildMonthlySeries({


### PR DESCRIPTION
### Motivation
- La vista Insights ("estado del mes") estaba tratando los egresos del mes como `gastos percibidos + crédito devengado`, pero para reflejar el cash flow real debe sumar `gastos percibidos + pagos de tarjeta` efectuados en el mes.

### Description
- Agregado `isApplicableCardPayment` a las importaciones en `app/api/analytics-data/route.ts` y usado para identificar pagos de tarjeta relevantes como egresos de caja. 
- En `buildMonthlySeries` la variable `perceived` ahora es `isPerceivedExpense(expense) || isApplicableCardPayment(expense)` para contabilizar pagos de tarjeta como percibidos. 
- Actualizados los filtros de endpoint para `rawExpenses` y `historicalExpenses` para incluir movimientos que cumplan `isApplicableCardPayment` además de los existentes.

### Testing
- Ejecutado `npm test` con `vitest` y todos los tests automáticos pasaron (`12` archivos, `46` tests OK). 
- Se intentó `npm test -- --runInBand` y falló por opción desconocida de `vitest`, lo cual es un tema de invocación del runner y no del cambio de lógica.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17aaff68f4832b870388d96841ea9c)