### PR TITLE
Corregir métricas 'Estado del mes' para usar solo cashflow

### DIFF
--- a/components/analytics/AnalysisView.tsx
+++ b/components/analytics/AnalysisView.tsx
@@ -11,6 +11,7 @@ type DrillTarget = 'estado_mes' | 'fuga' | 'habitos' | 'compromisos'
 
 interface Props {
   metrics: Metrics
+  estadoMesMetrics: Metrics
   compromisos: CompromisosData
   drill: DrillTarget | null
   setDrill: (d: DrillTarget | null) => void
@@ -21,6 +22,7 @@ interface Props {
 
 export function AnalysisView({
   metrics,
+  estadoMesMetrics,
   compromisos,
   drill,
   setDrill,
@@ -31,7 +33,7 @@ export function AnalysisView({
   const { currency, fugaSilenciosa, habitosMap } = metrics
 
   if (drill === 'estado_mes') {
-    return <DrillEstadoMes metrics={metrics} />
+    return <DrillEstadoMes metrics={estadoMesMetrics} />
   }
 
   if (drill === 'fuga') {
@@ -63,7 +65,7 @@ export function AnalysisView({
   // Overview: 3 bento cards
   return (
     <div className="px-5 space-y-3">
-      <EstadoMesCard metrics={metrics} onClick={() => setDrill('estado_mes')} />
+      <EstadoMesCard metrics={estadoMesMetrics} onClick={() => setDrill('estado_mes')} />
       <FugaSilenciosaCard
         data={fugaSilenciosa}
         currency={currency}

--- a/components/analytics/AnalyticsClient.tsx
+++ b/components/analytics/AnalyticsClient.tsx
@@ -39,6 +39,7 @@ const drillTitles: Record<Drill, string> = {
 
 interface Props {
   metrics: Metrics
+  estadoMesMetrics: Metrics
   compromisos: CompromisosData
   rawExpenses: Expense[]
   subscriptions: Subscription[]
@@ -53,6 +54,7 @@ interface Props {
 
 export function AnalyticsClient({
   metrics,
+  estadoMesMetrics,
   compromisos,
   rawExpenses,
   selectedMonth,
@@ -213,6 +215,7 @@ export function AnalyticsClient({
         {insightsOpen ? (
           <AnalysisView
             metrics={metrics}
+            estadoMesMetrics={estadoMesMetrics}
             compromisos={compromisos}
             drill={drill}
             setDrill={handleSetDrill}

--- a/components/analytics/AnalyticsDataLoader.tsx
+++ b/components/analytics/AnalyticsDataLoader.tsx
@@ -7,6 +7,7 @@ import { AnalyticsClient } from './AnalyticsClient'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { computeCompromisos } from '@/lib/analytics/computeCompromisos'
 import { computeMetrics } from '@/lib/analytics/computeMetrics'
+import { isCashflowExpense } from '@/lib/movement-classification'
 import { buildEmptyBudgetSnapshot } from '@/lib/budgets/computeBudgetMetrics'
 import type { BudgetSnapshot } from '@/lib/budgets/types'
 import { buildCardCycleAmountsMap } from '@/lib/card-cycle-amounts'
@@ -160,6 +161,12 @@ export function AnalyticsDataLoader({ selectedMonth, initialDrill }: Props) {
   const isCurrentMonth = today.getFullYear() === ymYear && today.getMonth() + 1 === ymMonth
 
   const metrics = computeMetrics(rawExpenses, ingresoMes, currency, selectedMonth)
+  const estadoMesMetrics = computeMetrics(
+    rawExpenses.filter(isCashflowExpense),
+    ingresoMes,
+    currency,
+    selectedMonth,
+  )
 
   const compromisos = computeCompromisos(
     compromisoExpenses,
@@ -176,6 +183,7 @@ export function AnalyticsDataLoader({ selectedMonth, initialDrill }: Props) {
   return (
     <AnalyticsClient
       metrics={metrics}
+      estadoMesMetrics={estadoMesMetrics}
       compromisos={compromisos}
       rawExpenses={rawExpenses}
       subscriptions={subscriptions}

--- a/lib/movement-classification.test.ts
+++ b/lib/movement-classification.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   isApplicableCardPayment,
   isCardPayment,
+  isCashflowExpense,
   isCreditAccruedExpense,
   isLegacyCardPayment,
   isPerceivedExpense,
@@ -75,6 +76,38 @@ describe('movement classification', () => {
       isCreditAccruedExpense({
         category: 'Pago de Tarjetas',
         payment_method: 'CREDIT',
+      }),
+    ).toBe(false)
+  })
+
+  it('classifies cashflow expenses as perceived plus applicable card payments', () => {
+    expect(
+      isCashflowExpense({
+        category: 'Supermercado',
+        payment_method: 'DEBIT',
+      }),
+    ).toBe(true)
+
+    expect(
+      isCashflowExpense({
+        category: 'Pago de Tarjetas',
+        payment_method: 'TRANSFER',
+        is_legacy_card_payment: false,
+      }),
+    ).toBe(true)
+
+    expect(
+      isCashflowExpense({
+        category: 'Indumentaria',
+        payment_method: 'CREDIT',
+      }),
+    ).toBe(false)
+
+    expect(
+      isCashflowExpense({
+        category: 'Pago de Tarjetas',
+        payment_method: 'TRANSFER',
+        is_legacy_card_payment: true,
       }),
     ).toBe(false)
   })

--- a/lib/movement-classification.ts
+++ b/lib/movement-classification.ts
@@ -23,3 +23,7 @@ export function isCreditAccruedExpense(expense: ExpenseLike): boolean {
 export function isPerceivedExpense(expense: ExpenseLike): boolean {
   return ['CASH', 'DEBIT', 'TRANSFER'].includes(expense.payment_method) && !isCardPayment(expense)
 }
+
+export function isCashflowExpense(expense: ExpenseLike): boolean {
+  return isPerceivedExpense(expense) || isApplicableCardPayment(expense)
+}


### PR DESCRIPTION
### Motivation
- El cálculo de “Estado del mes” debía sumar solo gastos percibidos más pagos de tarjeta aplicables (cashflow), y actualmente estaba incluyendo también gastos devengados de crédito, alterando la vista de análisis.

### Description
- Añadido `isCashflowExpense` en `lib/movement-classification.ts` para centralizar la regla: percibidos (`CASH`, `DEBIT`, `TRANSFER`) más `isApplicableCardPayment`, excluyendo pagos legacy y gastos `CREDIT` devengados.
- En `components/analytics/AnalyticsDataLoader.tsx` se calcula un snapshot adicional `estadoMesMetrics` con `rawExpenses.filter(isCashflowExpense)` y se pasa hacia la UI.
- `AnalyticsClient` y `AnalysisView` ahora reciben `estadoMesMetrics` y el `EstadoMesCard` / `DrillEstadoMes` usan exclusivamente ese snapshot, manteniendo `metrics` general sin cambios para el resto del análisis.
- Agregado test en `lib/movement-classification.test.ts` para validar `isCashflowExpense` y mantener la cobertura existente.

### Testing
- Ejecutado unit test específico con `npm test -- --run lib/movement-classification.test.ts`, que pasó exitosamente.
- Ejecutado `npx tsc --noEmit` para verificación de tipos, sin errores.
- Ejecutado `npx eslint` sobre los archivos modificados, sin errores en los cambios realizados (el lint global sigue fallando por issues preexistentes fuera de este cambio).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18bf89e964832ba201bbf85ed89f1e)