### PR TITLE
feat(movimientos): selector de rango de fechas en filtros

### DIFF
--- a/app/api/movimientos/route.ts
+++ b/app/api/movimientos/route.ts
@@ -42,6 +42,8 @@ export async function GET(request: Request) {
   const activeMonedas = monedas.length >= 2 ? [] : monedas
   const quincenaParam = parseInt(searchParams.get('quincena') ?? '0', 10)
   const quincena = quincenaParam === 1 || quincenaParam === 2 ? (quincenaParam as 1 | 2) : null
+  const fechaInicio = searchParams.get('fechaInicio') ?? null
+  const fechaFin    = searchParams.get('fechaFin')    ?? null
 
   const supabase = await createClient()
   const {
@@ -53,8 +55,16 @@ export async function GET(request: Request) {
   const startOfMonth = selectedMonth + '-01'
   const endOfMonth = addMonths(selectedMonth, 1) + '-01'
 
-  const effectiveStart = quincena === 2 ? selectedMonth + '-16' : startOfMonth
-  const effectiveEnd = quincena === 1 ? selectedMonth + '-16' : endOfMonth
+  let effectiveStart = quincena === 2 ? selectedMonth + '-16' : startOfMonth
+  let effectiveEnd   = quincena === 1 ? selectedMonth + '-16' : endOfMonth
+
+  if (fechaInicio) effectiveStart = fechaInicio
+  if (fechaFin) {
+    // fechaFin es inclusivo; la query usa lt(), así que sumamos 1 día
+    const d = new Date(fechaFin + 'T12:00:00')
+    d.setDate(d.getDate() + 1)
+    effectiveEnd = d.toISOString().slice(0, 10)
+  }
 
   const wantsExpenses = tipos.length === 0 || tipos.some((t) => t === 'gasto' || t === 'suscripcion')
   const wantsIncome = tipos.length === 0 || tipos.includes('ingreso')

--- a/components/movimientos/FiltroSheet.tsx
+++ b/components/movimientos/FiltroSheet.tsx
@@ -12,17 +12,20 @@ export type OrigenFilter  = 'percibido' | 'tarjeta' | 'pago_tarjeta'
 export type MonedaFilter  = 'ARS' | 'USD'
 
 export interface ActiveFilters {
-  tipos:      TipoFilter[]
-  origenes:   OrigenFilter[]
-  cuentas:    string[]
-  tarjetas:   string[]
-  categorias: string[]
-  monedas:    MonedaFilter[]
-  quincena:   1 | 2 | null
+  tipos:       TipoFilter[]
+  origenes:    OrigenFilter[]
+  cuentas:     string[]
+  tarjetas:    string[]
+  categorias:  string[]
+  monedas:     MonedaFilter[]
+  quincena:    1 | 2 | null
+  fechaInicio: string | null  // YYYY-MM-DD
+  fechaFin:    string | null  // YYYY-MM-DD
 }
 
 export const EMPTY_FILTERS: ActiveFilters = {
   tipos: [], origenes: [], cuentas: [], tarjetas: [], categorias: [], monedas: [], quincena: null,
+  fechaInicio: null, fechaFin: null,
 }
 
 export function countFilters(f: ActiveFilters): number {
@@ -33,7 +36,8 @@ export function countFilters(f: ActiveFilters): number {
     f.tarjetas.length +
     f.categorias.length +
     f.monedas.length +
-    (f.quincena ? 1 : 0)
+    (f.quincena ? 1 : 0) +
+    (f.fechaInicio || f.fechaFin ? 1 : 0)
   )
 }
 
@@ -83,16 +87,28 @@ function isTarjetaMode(origenes: OrigenFilter[]): boolean {
   return origenes.length === 1 && origenes[0] === 'tarjeta'
 }
 
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+function monthBounds(ym: string): { start: string; end: string } {
+  const [year, month] = ym.split('-').map(Number)
+  const lastDay = new Date(year, month, 0).getDate()
+  return {
+    start: `${ym}-01`,
+    end: `${ym}-${String(lastDay).padStart(2, '0')}`,
+  }
+}
+
 // ─── Props ────────────────────────────────────────────────────────────────────
 
 interface Props {
-  open:       boolean
-  onClose:    () => void
-  onApply:    (f: ActiveFilters) => void
-  initial:    ActiveFilters
-  accounts:   Account[]
-  cards:      Card[]
-  categories: string[]
+  open:          boolean
+  onClose:       () => void
+  onApply:       (f: ActiveFilters) => void
+  initial:       ActiveFilters
+  accounts:      Account[]
+  cards:         Card[]
+  categories:    string[]
+  selectedMonth: string
 }
 
 // ─── Collapsible section header ───────────────────────────────────────────────
@@ -119,7 +135,7 @@ function SectionHeader({
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function FiltroSheet({ open, onClose, onApply, initial, accounts, cards, categories }: Props) {
+export function FiltroSheet({ open, onClose, onApply, initial, accounts, cards, categories, selectedMonth }: Props) {
   const [f, setF]                       = useState<ActiveFilters>(initial)
   const [cuentasOpen, setCuentasOpen]   = useState(false)
   const [tarjetasOpen, setTarjetasOpen] = useState(false)
@@ -136,6 +152,7 @@ export function FiltroSheet({ open, onClose, onApply, initial, accounts, cards, 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
 
+  const bounds       = monthBounds(selectedMonth)
   const showOrigen   = origenVisible(f.tipos)
   const tarjetaMode  = isTarjetaMode(f.origenes)
   const total        = countFilters(f)
@@ -317,6 +334,42 @@ export function FiltroSheet({ open, onClose, onApply, initial, accounts, cards, 
                 {label}
               </button>
             ))}
+          </div>
+        </div>
+
+        {/* 6. Período */}
+        <div>
+          <p className="type-label text-text-tertiary mb-3">Período</p>
+          <div className="flex items-end gap-2">
+            <div className="flex flex-1 flex-col gap-1.5">
+              <p className="text-[11px] text-text-disabled">Desde</p>
+              <input
+                type="date"
+                value={f.fechaInicio ?? bounds.start}
+                min={bounds.start}
+                max={f.fechaFin ?? bounds.end}
+                onChange={(e) => {
+                  const val = e.target.value
+                  setF((prev) => ({ ...prev, fechaInicio: val === bounds.start ? null : val }))
+                }}
+                className="w-full rounded-xl border border-bg-secondary bg-white/60 px-3 py-2 text-[13px] text-text-primary outline-none focus:border-primary/40"
+              />
+            </div>
+            <span className="mb-2.5 text-[13px] text-text-disabled">→</span>
+            <div className="flex flex-1 flex-col gap-1.5">
+              <p className="text-[11px] text-text-disabled">Hasta</p>
+              <input
+                type="date"
+                value={f.fechaFin ?? bounds.end}
+                min={f.fechaInicio ?? bounds.start}
+                max={bounds.end}
+                onChange={(e) => {
+                  const val = e.target.value
+                  setF((prev) => ({ ...prev, fechaFin: val === bounds.end ? null : val }))
+                }}
+                className="w-full rounded-xl border border-bg-secondary bg-white/60 px-3 py-2 text-[13px] text-text-primary outline-none focus:border-primary/40"
+              />
+            </div>
           </div>
         </div>
 

--- a/components/movimientos/MovimientosClient.tsx
+++ b/components/movimientos/MovimientosClient.tsx
@@ -73,7 +73,11 @@ function matchesSet<T extends string>(current: T[], target: T[]): boolean {
   return current.length === target.length && target.every((item) => current.includes(item))
 }
 
-function buildFilterSummary(f: ActiveFilters, accounts: Account[], cards: Card[]): string {
+function fmtDate(d: string): string {
+  return d.slice(8) + '/' + d.slice(5, 7)
+}
+
+function buildFilterSummary(f: ActiveFilters, accounts: Account[], cards: Card[], selectedMonth: string): string {
   const parts: string[] = []
   f.tipos.filter((t) => t !== 'suscripcion').forEach((t) => parts.push(TIPO_LABELS[t] ?? t))
   if (isPercibidosOrigen(f.origenes)) {
@@ -104,6 +108,17 @@ function buildFilterSummary(f: ActiveFilters, accounts: Account[], cards: Card[]
     f.monedas.forEach((m) => parts.push(m))
   }
   if (f.quincena) parts.push(f.quincena === 1 ? '1ra quincena' : '2da quincena')
+
+  if (f.fechaInicio || f.fechaFin) {
+    const [, month] = selectedMonth.split('-').map(Number)
+    const lastDay = new Date(Number(selectedMonth.split('-')[0]), month, 0).getDate()
+    const defaultStart = `${selectedMonth}-01`
+    const defaultEnd = `${selectedMonth}-${String(lastDay).padStart(2, '0')}`
+    const start = f.fechaInicio ?? defaultStart
+    const end = f.fechaFin ?? defaultEnd
+    parts.push(`${fmtDate(start)} → ${fmtDate(end)}`)
+  }
+
   return parts.join(' · ')
 }
 
@@ -170,6 +185,8 @@ export function MovimientosClient({ initialMonth, initialData, initialCategoria,
           params.set('categorias', filters.categorias.join(','))
         if (filters.monedas.length > 0) params.set('monedas', filters.monedas.join(','))
         if (filters.quincena) params.set('quincena', String(filters.quincena))
+        if (filters.fechaInicio) params.set('fechaInicio', filters.fechaInicio)
+        if (filters.fechaFin) params.set('fechaFin', filters.fechaFin)
 
         const res = await fetch(`/api/movimientos?${params}`)
         if (!res.ok) throw new Error('fetch failed')
@@ -217,8 +234,14 @@ export function MovimientosClient({ initialMonth, initialData, initialCategoria,
     router.refresh()
   }, [fetchMovements, selectedMonth, activeFilters, router])
 
-  const handlePrevMonth = () => setSelectedMonth((m) => addMonths(m, -1))
-  const handleNextMonth = () => setSelectedMonth((m) => addMonths(m, 1))
+  const handlePrevMonth = () => {
+    setSelectedMonth((m) => addMonths(m, -1))
+    setActiveFilters((prev) => ({ ...prev, fechaInicio: null, fechaFin: null }))
+  }
+  const handleNextMonth = () => {
+    setSelectedMonth((m) => addMonths(m, 1))
+    setActiveFilters((prev) => ({ ...prev, fechaInicio: null, fechaFin: null }))
+  }
 
   const handleOrigenClick = (origen: OrigenFilter) => {
     setActiveFilters((prev) => {
@@ -236,9 +259,11 @@ export function MovimientosClient({ initialMonth, initialData, initialCategoria,
   const handleQuickFilter = (quick: QuickFilterKey) => {
     setActiveFilters((prev) => {
       const preservedBase = {
-        cuentas: prev.cuentas,
-        monedas: prev.monedas,
-        quincena: prev.quincena,
+        cuentas:     prev.cuentas,
+        monedas:     prev.monedas,
+        quincena:    prev.quincena,
+        fechaInicio: prev.fechaInicio,
+        fechaFin:    prev.fechaFin,
       }
 
       switch (quick) {
@@ -293,7 +318,8 @@ export function MovimientosClient({ initialMonth, initialData, initialCategoria,
     activeFilters.cuentas.length +
     activeFilters.categorias.length +
     activeFilters.monedas.length +
-    (activeFilters.quincena ? 1 : 0)
+    (activeFilters.quincena ? 1 : 0) +
+    (activeFilters.fechaInicio || activeFilters.fechaFin ? 1 : 0)
 
   const quickChipClass = (active: boolean) =>
     [
@@ -410,7 +436,7 @@ export function MovimientosClient({ initialMonth, initialData, initialCategoria,
               className="glass-1 flex min-w-0 max-w-[70%] items-center gap-1.5 rounded-pill py-1.5 pl-3 pr-2.5 transition-opacity active:opacity-60"
             >
               <span className="truncate text-[12px] font-medium text-primary">
-                {buildFilterSummary(activeFilters, accounts, cards)}
+                {buildFilterSummary(activeFilters, accounts, cards, selectedMonth)}
               </span>
               <X size={11} weight="bold" className="shrink-0 text-primary/60" />
             </button>
@@ -459,6 +485,7 @@ export function MovimientosClient({ initialMonth, initialData, initialCategoria,
         accounts={accounts}
         cards={cards}
         categories={categories}
+        selectedMonth={selectedMonth}
       />
     </div>
   )


### PR DESCRIPTION
## Resumen

- Agrega sección **Período** al `FiltroSheet` con inputs de fecha inicio y fin, limitados al mes activo
- Los inputs se pre-populan con el primer y último día del mes; solo cuentan como filtro activo si el usuario los modifica
- Al cambiar de mes, las fechas se resetean automáticamente
- El chip de filtros activos muestra el rango en formato `01/06 → 15/06`
- Los quick filters (Gastos, Ingresos, Tarjetas) preservan el rango de fechas al aplicarse
- La API recibe `fechaInicio` y `fechaFin` como parámetros y filtra el período exacto en Supabase

## Archivos modificados

- `components/movimientos/FiltroSheet.tsx` — nuevos campos en `ActiveFilters`, UI de Período
- `components/movimientos/MovimientosClient.tsx` — parámetros en fetch, reset en cambio de mes, summary
- `app/api/movimientos/route.ts` — parsing de `fechaInicio`/`fechaFin`, ajuste de `effectiveStart`/`effectiveEnd`

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNimtohPGd5ybawrkwyFqM)_