### PR TITLE
feat(web): panel desktop editorial — Saldo Vivo campeón, Disponible Real subhéroe, brecha explicada

### DIFF
--- a/components/dashboard/desktop/DesktopAttentionPanel.tsx
+++ b/components/dashboard/desktop/DesktopAttentionPanel.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { CreditCard, PencilSimple, Receipt } from '@phosphor-icons/react'
+import { BLUE, CARD_STYLE, LABEL_STYLE } from './desktop-ui'
+import type { AttentionSignal } from './desktop-dashboard-model'
+
+type Money = (n: number, currency?: 'ARS' | 'USD') => string
+
+const TONE: Record<AttentionSignal['tone'], { color: string; bg: string }> = {
+  high: { color: '#A61E1E', bg: 'rgba(166,30,30,0.09)' },
+  medium: { color: '#B84A12', bg: 'rgba(184,74,18,0.10)' },
+  low: { color: BLUE, bg: 'rgba(33,120,168,0.09)' },
+}
+
+function signalIcon(id: string): typeof CreditCard {
+  if (id.startsWith('closing-') || id.startsWith('due-')) return CreditCard
+  if (id.startsWith('extra-')) return Receipt
+  return PencilSimple
+}
+
+export function DesktopAttentionPanel({ signals, money }: { signals: AttentionSignal[]; money: Money }) {
+  return (
+    <div style={{ ...CARD_STYLE, padding: '24px 26px', height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: signals.length > 0 ? 4 : 14 }}>
+        <span style={LABEL_STYLE}>Atención ahora</span>
+        {signals.length > 0 && (
+          <span style={{ minWidth: 22, height: 22, padding: '0 7px', borderRadius: 9999, background: 'rgba(33,120,168,0.09)', color: BLUE, fontSize: 12, fontWeight: 700, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+            {signals.length}
+          </span>
+        )}
+      </div>
+
+      {signals.length === 0 ? (
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+          <p style={{ margin: 0, fontSize: 15, fontWeight: 700, color: '#0D1829' }}>No hay señales urgentes.</p>
+          <p style={{ margin: '8px 0 0', fontSize: 13, color: '#4A6070', lineHeight: 1.55 }}>
+            Gota va a marcarte algo cuando cambie tu margen, tus vencimientos o tu ritmo.
+          </p>
+        </div>
+      ) : (
+        <div>
+          {signals.map((signal, i) => {
+            const tone = TONE[signal.tone]
+            const IconCmp = signalIcon(signal.id)
+            return (
+              <div key={signal.id} style={{ display: 'flex', alignItems: 'flex-start', gap: 13, padding: '15px 0', borderTop: i > 0 ? '1px solid rgba(33,120,168,0.07)' : 'none' }}>
+                <span style={{ width: 34, height: 34, borderRadius: 10, flexShrink: 0, marginTop: 1, background: tone.bg, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <IconCmp weight="light" size={18} color={tone.color} />
+                </span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 10 }}>
+                    <span style={{ fontSize: 14, fontWeight: 700, color: '#0D1829', lineHeight: 1.35 }}>{signal.title}</span>
+                    <span style={{ fontSize: 11.5, fontWeight: 600, color: '#90A4B0', flexShrink: 0, whiteSpace: 'nowrap' }}>{signal.dateLabel}</span>
+                  </div>
+                  <div style={{ fontSize: 12.5, color: '#4A6070', marginTop: 3, lineHeight: 1.45 }}>{signal.detail}</div>
+                  {signal.amount !== undefined && (
+                    <div style={{ fontSize: 12.5, color: '#4A6070', marginTop: 4 }}>
+                      <strong style={{ color: '#0D1829', fontVariantNumeric: 'tabular-nums' }}>{money(signal.amount, signal.currency)}</strong>
+                      {signal.amountCaption ? ` ${signal.amountCaption}` : ''}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/dashboard/desktop/DesktopCommitmentsPanel.tsx
+++ b/components/dashboard/desktop/DesktopCommitmentsPanel.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { ArrowRight } from '@phosphor-icons/react'
+import type { CompromisosData } from '@/lib/analytics/computeCompromisos'
+import { BLUE, CARD_STYLE, LABEL_STYLE } from './desktop-ui'
+import type { NavId } from './desktop-chrome'
+import type { DesktopHeroStats } from './desktop-dashboard-model'
+
+type Money = (n: number, currency?: 'ARS' | 'USD') => string
+
+/** Explica la brecha entre Saldo Vivo y Disponible Real con el mismo total del hero. */
+export function DesktopCommitmentsPanel({
+  stats,
+  compromisos,
+  money,
+  onNav,
+}: {
+  stats: DesktopHeroStats
+  compromisos: CompromisosData | null
+  money: Money
+  onNav: (id: NavId) => void
+}) {
+  const hasGap = stats.brecha > 0.5
+  const hasDetail = compromisos !== null
+
+  const rows = hasDetail
+    ? [
+        {
+          key: 'pagar',
+          label: 'Resúmenes por pagar',
+          sub: 'Ciclos ya cerrados, con vencimiento por delante.',
+          amount: stats.compromisosProximos,
+          color: BLUE,
+        },
+        {
+          key: 'curso',
+          label: 'Tarjeta en curso',
+          sub: 'Consumos del ciclo actual, todavía sin cerrar.',
+          amount: stats.tarjetaEnCurso,
+          color: '#1B7E9E',
+        },
+        {
+          key: 'resto',
+          label: 'Otros consumos de tarjeta',
+          sub: 'Sin ciclo asignado todavía.',
+          amount: stats.reservas,
+          color: '#90A4B0',
+        },
+      ].filter((row) => row.amount > 0.5)
+    : []
+
+  const rowsTotal = rows.reduce((sum, row) => sum + row.amount, 0)
+  const detailMismatch = hasDetail && hasGap && Math.abs(rowsTotal - stats.brecha) > Math.max(1, stats.brecha * 0.01)
+
+  const pendingSubsTotal =
+    compromisos?.tarjetas.reduce(
+      (sum, card) => sum + card.pendingSubs.reduce((subSum, sub) => subSum + sub.amount, 0),
+      0,
+    ) ?? 0
+
+  return (
+    <div style={{ ...CARD_STYLE, padding: '24px 26px', height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
+        <span style={LABEL_STYLE}>Ya tiene destino</span>
+        <button
+          type="button"
+          onClick={() => onNav('tarjetas')}
+          style={{ background: 'transparent', border: 0, cursor: 'pointer', padding: 0, display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 12, fontWeight: 600, color: BLUE, fontFamily: 'inherit' }}
+        >
+          Ver tarjetas <ArrowRight size={11} />
+        </button>
+      </div>
+
+      {!hasGap ? (
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+          <p style={{ margin: 0, fontSize: 15, fontWeight: 700, color: '#0D1829' }}>Hoy no hay plata comprometida.</p>
+          <p style={{ margin: '8px 0 0', fontSize: 13, color: '#4A6070', lineHeight: 1.55 }}>
+            Tu Saldo Vivo y tu Disponible Real son lo mismo: no tenés consumos de tarjeta pendientes.
+          </p>
+        </div>
+      ) : (
+        <>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, marginBottom: 6 }}>
+            <span style={{ fontSize: 28, fontWeight: 800, letterSpacing: '-0.035em', color: '#0D1829', fontVariantNumeric: 'tabular-nums' }}>
+              {money(stats.brecha)}
+            </span>
+            <span style={{ fontSize: 13, color: '#90A4B0' }}>separado de tu Disponible Real</span>
+          </div>
+          <p style={{ margin: '0 0 16px', fontSize: 12.5, color: '#4A6070', lineHeight: 1.5 }}>
+            Es la diferencia entre tu Saldo Vivo y lo que podés usar hoy.
+          </p>
+
+          {rows.length > 0 && (
+            <div style={{ display: 'flex', height: 8, borderRadius: 4, overflow: 'hidden', gap: 2, marginBottom: 6, background: 'rgba(33,120,168,0.06)' }}>
+              {rows.map((row) => (
+                <div key={row.key} style={{ flex: row.amount / rowsTotal, background: row.color }} />
+              ))}
+            </div>
+          )}
+
+          {!hasDetail ? (
+            <p style={{ margin: '10px 0 0', fontSize: 13, color: '#4A6070', lineHeight: 1.55 }}>
+              El detalle por tarjeta todavía no está disponible.
+            </p>
+          ) : (
+            <div>
+              {rows.map((row, i) => (
+                <div key={row.key} style={{ display: 'flex', alignItems: 'flex-start', gap: 12, padding: '13px 0', borderBottom: i < rows.length - 1 ? '1px solid rgba(33,120,168,0.07)' : 'none' }}>
+                  <span style={{ width: 8, height: 8, borderRadius: 9999, flexShrink: 0, marginTop: 5, background: row.color }} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 14, fontWeight: 600, color: '#0D1829' }}>{row.label}</div>
+                    <div style={{ fontSize: 11.5, color: '#90A4B0', marginTop: 2 }}>{row.sub}</div>
+                  </div>
+                  <span style={{ fontSize: 14.5, fontWeight: 700, color: '#0D1829', fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
+                    {money(row.amount)}
+                  </span>
+                </div>
+              ))}
+              {detailMismatch && (
+                <p style={{ margin: '10px 0 0', fontSize: 11, color: '#90A4B0', lineHeight: 1.5 }}>
+                  El detalle por tarjeta puede diferir levemente del total.
+                </p>
+              )}
+            </div>
+          )}
+
+          {pendingSubsTotal > 0.5 && (
+            <div style={{ marginTop: 'auto', paddingTop: 14, borderTop: '1px dashed rgba(33,120,168,0.14)' }}>
+              <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
+                <span style={{ fontSize: 13, fontWeight: 600, color: '#4A6070' }}>Suscripciones por facturar</span>
+                <span style={{ fontSize: 13.5, fontWeight: 700, color: '#4A6070', fontVariantNumeric: 'tabular-nums' }}>{money(pendingSubsTotal)}</span>
+              </div>
+              <p style={{ margin: '3px 0 0', fontSize: 11.5, color: '#90A4B0', lineHeight: 1.45 }}>
+                Van a sumarse a próximos ciclos; todavía no cuentan acá.
+              </p>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/components/dashboard/desktop/DesktopDashboardShell.tsx
+++ b/components/dashboard/desktop/DesktopDashboardShell.tsx
@@ -8,10 +8,11 @@ import type { CompromisosData } from '@/lib/analytics/computeCompromisos'
 import type { DashboardApiData } from '@/lib/server/dashboard-queries'
 import type { BudgetItemMetrics, BudgetSnapshot, BudgetStatus } from '@/lib/budgets/types'
 import type { GoalPaceStatus, GoalWithMetrics } from '@/lib/goals/types'
+import { BlueHeaderZone } from '@/components/ui/BlueHeaderZone'
 import { BLUE, CARD_STYLE, CatSquare, fmtMoney, LABEL_STYLE, MAXW, PageHeader } from './desktop-ui'
 import { DesktopTopnav, type NavId } from './desktop-chrome'
 import { CuentasModule, MovimientosModule, PresupuestoModule, type AccountRow } from './desktop-modules'
-import { DesktopPanelHero } from './DesktopPanelHero'
+import { DisponibleRelationCard, SaldoVivoBlueHero } from './DesktopPanelHero'
 import { DesktopAttentionPanel } from './DesktopAttentionPanel'
 import { DesktopUpcomingTimeline } from './DesktopUpcomingTimeline'
 import { DesktopCommitmentsPanel } from './DesktopCommitmentsPanel'
@@ -210,6 +211,10 @@ export function DesktopDashboardShell({
     gastosMes,
   }
 
+  // El Panel con cuentas lleva el hero dentro de la blue-zone; el contenido
+  // blanco la solapa con el overlap fijo de -24px del patrón S5.
+  const isPanelHero = activeNav === 'inicio' && hasAccounts
+
   return (
     <div style={{ minHeight: '100vh', background: '#F8FBFD', color: '#0D1829', fontFamily: 'var(--font-sans)' }}>
       <style>{`
@@ -220,19 +225,43 @@ export function DesktopDashboardShell({
           .dual { grid-template-columns: 1fr !important; }
         }
       `}</style>
-      <DesktopTopnav
-        active={activeNav}
-        onNav={handleNav}
-        hidden={hidden}
-        onToggleHidden={() => setHidden((h) => !h)}
-        quote={quote}
-        selectedMonth={selectedMonth}
-        onSelectMonth={onSelectMonth}
-        avatarInitial={avatarInitial}
-        onOpenSettings={onOpenSettings}
-      />
+      <BlueHeaderZone>
+        <DesktopTopnav
+          active={activeNav}
+          onNav={handleNav}
+          hidden={hidden}
+          onToggleHidden={() => setHidden((h) => !h)}
+          quote={quote}
+          selectedMonth={selectedMonth}
+          onSelectMonth={onSelectMonth}
+          avatarInitial={avatarInitial}
+          onOpenSettings={onOpenSettings}
+        />
+        {isPanelHero && (
+          <SaldoVivoBlueHero
+            greeting={
+              <>
+                {greetingByHour()}, <strong style={{ color: '#FFFFFF', fontWeight: 700 }}>{firstName}</strong>.{' '}
+                <span style={{ color: 'rgba(255,255,255,0.55)' }}>Esto es lo tuyo, hoy.</span>
+              </>
+            }
+            stats={stats}
+            heroBreakdown={heroBreakdown}
+            viewCurrency={viewCurrency}
+            hidden={hidden}
+          />
+        )}
+      </BlueHeaderZone>
 
-      <main style={{ maxWidth: MAXW, margin: '0 auto', padding: '34px 40px 96px' }}>
+      <main
+        style={{
+          maxWidth: MAXW,
+          margin: '0 auto',
+          padding: isPanelHero ? '0 40px 96px' : '34px 40px 96px',
+          marginTop: isPanelHero ? -24 : 0,
+          position: 'relative',
+        }}
+      >
           {!hasAccounts ? (
             <section style={{ ...CARD_STYLE, padding: '48px 40px' }}>
               <p style={{ ...LABEL_STYLE, color: BLUE, marginBottom: 18 }}>Inicio</p>
@@ -251,20 +280,9 @@ export function DesktopDashboardShell({
             </section>
           ) : activeNav === 'inicio' ? (
             <>
-              <p style={{ margin: '0 0 30px', fontSize: 14, color: '#4A6070' }}>
-                {greetingByHour()}, <strong style={{ color: '#0D1829', fontWeight: 700 }}>{firstName}</strong>.{' '}
-                <span style={{ color: '#90A4B0' }}>Esto es lo tuyo, hoy.</span>
-              </p>
-
-              {/* 1 · HERO: Saldo Vivo → Disponible Real + Atención ahora */}
-              <div className="hero-grid" style={{ display: 'grid', gridTemplateColumns: '1.5fr 1fr', gap: 28, alignItems: 'stretch', marginBottom: 44 }}>
-                <DesktopPanelHero
-                  stats={stats}
-                  heroBreakdown={heroBreakdown}
-                  viewCurrency={viewCurrency}
-                  hidden={hidden}
-                  money={money}
-                />
+              {/* 1 · Subhéroe sobre la zona blanca: reparto del Saldo Vivo + Atención ahora */}
+              <div className="hero-grid" style={{ display: 'grid', gridTemplateColumns: '1.5fr 1fr', gap: 24, alignItems: 'stretch', marginBottom: 40 }}>
+                <DisponibleRelationCard stats={stats} hidden={hidden} money={money} />
                 <DesktopAttentionPanel signals={attention} money={money} />
               </div>
 

--- a/components/dashboard/desktop/DesktopDashboardShell.tsx
+++ b/components/dashboard/desktop/DesktopDashboardShell.tsx
@@ -2,37 +2,20 @@
 
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
-import { ArrowRight, ArrowUpRight, CaretRight, Wallet } from '@phosphor-icons/react'
+import { ArrowRight } from '@phosphor-icons/react'
 import type { AnalyticsApiData } from '@/components/analytics/AnalyticsDataLoader'
 import type { CompromisosData } from '@/lib/analytics/computeCompromisos'
 import type { DashboardApiData } from '@/lib/server/dashboard-queries'
 import type { BudgetItemMetrics, BudgetSnapshot, BudgetStatus } from '@/lib/budgets/types'
 import type { GoalPaceStatus, GoalWithMetrics } from '@/lib/goals/types'
-import {
-  BLUE,
-  CARD_STYLE,
-  CatSquare,
-  currencySymbol,
-  fmtMoney,
-  LABEL_STYLE,
-  MAXW,
-  PageHeader,
-  SectionTitle,
-  SIDEBAR_W,
-} from './desktop-ui'
-import { DesktopSidebar, DesktopTopbar, type NavId } from './desktop-chrome'
-import {
-  AtencionAhoraModule,
-  CompromisosTotalesModule,
-  CuentasModule,
-  InsightsModule,
-  MetasModule,
-  MovimientosModule,
-  PresupuestoModule,
-  Proximos30Module,
-  TarjetasModule,
-  type AccountRow,
-} from './desktop-modules'
+import { BLUE, CARD_STYLE, CatSquare, fmtMoney, LABEL_STYLE, MAXW, PageHeader } from './desktop-ui'
+import { DesktopTopnav, type NavId } from './desktop-chrome'
+import { CuentasModule, MovimientosModule, PresupuestoModule, type AccountRow } from './desktop-modules'
+import { DesktopPanelHero } from './DesktopPanelHero'
+import { DesktopAttentionPanel } from './DesktopAttentionPanel'
+import { DesktopUpcomingTimeline } from './DesktopUpcomingTimeline'
+import { DesktopCommitmentsPanel } from './DesktopCommitmentsPanel'
+import { DesktopSecondarySummary } from './DesktopSecondarySummary'
 import {
   AnalisisView,
   CompromisosView,
@@ -47,7 +30,6 @@ import {
   buildDesktopHeroStats,
   buildHorizonEvents,
   buildRecentActivityItems,
-  selectDashboardGoals,
 } from './desktop-dashboard-model'
 
 type CotizacionApiData = {
@@ -97,21 +79,6 @@ function accountTypeLabel(type: 'bank' | 'cash' | 'digital'): string {
   if (type === 'bank') return 'Banco'
   if (type === 'digital') return 'Digital'
   return 'Efectivo'
-}
-
-/** Builds SVG polyline points for a sparkline in a viewBox */
-function buildSparklinePath(values: number[], w = 360, h = 150): string {
-  if (values.length < 2) return ''
-  const max = Math.max(...values)
-  const min = Math.min(...values)
-  const range = Math.max(max - min, 1)
-  return values
-    .map((v, i) => {
-      const x = (i / (values.length - 1)) * w
-      const y = h - ((v - min) / range) * (h * 0.78) - h * 0.1
-      return `${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`
-    })
-    .join(' ')
 }
 
 // ─── Budget status meta ──────────────────────────────────────
@@ -198,11 +165,14 @@ export function DesktopDashboardShell({
     [data.accounts, data.allUltimos, data.incomeEntries, data.transfers],
   )
 
-  // KPI: gastos del mes (percibidos)
+  // KPI: gastos del mes (percibidos). El fallback replica la definición de
+  // percibido (sin consumos de crédito ni pagos de tarjeta) para no inflar la lectura.
   const gastosMes = useMemo(() => {
     const current = analyticsData?.monthlySeries?.find((m) => m.isCurrent)
     if (current != null) return current.percibidoTotal
-    return data.allUltimos.filter((e) => e.currency === viewCurrency).reduce((s, e) => s + e.amount, 0)
+    return data.allUltimos
+      .filter((e) => e.currency === viewCurrency && e.payment_method !== 'CREDIT' && e.category !== 'Pago de Tarjetas')
+      .reduce((s, e) => s + e.amount, 0)
   }, [analyticsData?.monthlySeries, data.allUltimos, viewCurrency])
 
   const ingresosMes = useMemo(
@@ -211,31 +181,6 @@ export function DesktopDashboardShell({
       data.incomeEntries.filter((e) => e.currency === viewCurrency).reduce((s, e) => s + e.amount, 0),
     [analyticsData?.ingresoMes, data.incomeEntries, viewCurrency],
   )
-
-  // Sparkline: expense trend inverted (less spending = higher = healthier)
-  const sparklinePath = useMemo(() => {
-    const series = analyticsData?.monthlySeries.slice(-6) ?? []
-    if (series.length < 2) return ''
-    return buildSparklinePath(series.map((m) => -m.percibidoTotal))
-  }, [analyticsData?.monthlySeries])
-
-  const sparklineMonths = useMemo(
-    () => (analyticsData?.monthlySeries.slice(-6) ?? []).map((m) => m.label.slice(0, 3).toUpperCase()),
-    [analyticsData?.monthlySeries],
-  )
-
-  // Insight: month-over-month expense trend
-  const gastoTrendPct = useMemo(() => {
-    const series = analyticsData?.monthlySeries ?? []
-    const idx = series.findIndex((m) => m.isCurrent)
-    if (idx <= 0) return null
-    const prev = series[idx - 1]
-    if (!prev || prev.percibidoTotal <= 0) return null
-    return ((series[idx].percibidoTotal - prev.percibidoTotal) / prev.percibidoTotal) * 100
-  }, [analyticsData?.monthlySeries])
-
-  const dashboardGoals = useMemo(() => selectDashboardGoals(data.goals), [data.goals])
-  const activeGoalsCount = useMemo(() => data.goals.filter((g) => g.status === 'active').length, [data.goals])
 
   const accountRows = useMemo<AccountRow[]>(
     () =>
@@ -250,14 +195,9 @@ export function DesktopDashboardShell({
     [data.accounts, data.accountBalances],
   )
 
-  const tarjetas = compromisos?.tarjetas ?? []
-
   const hasAccounts = data.accounts.length > 0
   const firstName = firstNameFromEmail(userEmail)
   const avatarInitial = firstName.charAt(0).toUpperCase()
-  const flujoResult = ingresosMes - gastosMes
-  const tasaAhorroPct = ingresosMes > 0 ? (flujoResult / ingresosMes) * 100 : null
-  const [saldoInt, saldoDec] = stats.saldoVivo.toFixed(2).split('.')
 
   const viewProps = {
     data,
@@ -270,49 +210,29 @@ export function DesktopDashboardShell({
     gastosMes,
   }
 
-  const greeting =
-    activeNav === 'inicio' ? (
-      <>
-        {greetingByHour()}, <strong style={{ color: '#0D1829', fontWeight: 700 }}>{firstName}</strong>.{' '}
-        <span style={{ color: '#90A4B0' }}>Esto es lo tuyo, hoy.</span>
-      </>
-    ) : (
-      <span style={{ color: '#90A4B0' }}>
-        gota · <span style={{ color: '#4A6070', fontWeight: 600, textTransform: 'capitalize' }}>{activeNav}</span>
-      </span>
-    )
-
   return (
     <div style={{ minHeight: '100vh', background: '#F8FBFD', color: '#0D1829', fontFamily: 'var(--font-sans)' }}>
       <style>{`
         @media (max-width: 1180px) {
-          .panel-grid { grid-template-columns: minmax(0,1fr) !important; }
-          .panel-rail { position: static !important; display: grid !important; grid-template-columns: 1fr 1fr; gap: 20px; }
+          .hero-grid { grid-template-columns: minmax(0,1fr) !important; }
         }
         @media (max-width: 860px) {
           .dual { grid-template-columns: 1fr !important; }
-          .panel-rail { grid-template-columns: 1fr !important; }
         }
       `}</style>
-      <DesktopSidebar
+      <DesktopTopnav
         active={activeNav}
         onNav={handleNav}
-        userName={firstName}
+        hidden={hidden}
+        onToggleHidden={() => setHidden((h) => !h)}
+        quote={quote}
+        selectedMonth={selectedMonth}
+        onSelectMonth={onSelectMonth}
         avatarInitial={avatarInitial}
         onOpenSettings={onOpenSettings}
       />
 
-      <div style={{ marginLeft: SIDEBAR_W }}>
-        <DesktopTopbar
-          greeting={greeting}
-          hidden={hidden}
-          onToggleHidden={() => setHidden((h) => !h)}
-          quote={quote}
-          selectedMonth={selectedMonth}
-          onSelectMonth={onSelectMonth}
-        />
-
-        <main style={{ maxWidth: MAXW, margin: '0 auto', padding: '32px 40px 96px' }}>
+      <main style={{ maxWidth: MAXW, margin: '0 auto', padding: '34px 40px 96px' }}>
           {!hasAccounts ? (
             <section style={{ ...CARD_STYLE, padding: '48px 40px' }}>
               <p style={{ ...LABEL_STYLE, color: BLUE, marginBottom: 18 }}>Inicio</p>
@@ -331,167 +251,42 @@ export function DesktopDashboardShell({
             </section>
           ) : activeNav === 'inicio' ? (
             <>
-              {/* 1 · SALDO VIVO */}
-              <div
-                style={{
-                  background: 'linear-gradient(135deg, #2178A8 0%, #15597F 100%)',
-                  borderRadius: 24,
-                  padding: '34px 38px 36px',
-                  marginBottom: 44,
-                  boxShadow: '0 18px 44px rgba(21,89,127,0.28)',
-                  position: 'relative',
-                  overflow: 'hidden',
-                }}
-              >
-                <div style={{ position: 'absolute', top: -80, right: -40, width: 320, height: 320, borderRadius: '50%', background: 'radial-gradient(circle, rgba(255,255,255,0.10) 0%, rgba(255,255,255,0) 70%)', pointerEvents: 'none' }} />
-                <div style={{ display: 'grid', gridTemplateColumns: '1.35fr 1fr', gap: 48, alignItems: 'center', position: 'relative' }}>
-                  {/* LEFT */}
-                  <div>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
-                      <span style={{ ...LABEL_STYLE, color: 'rgba(255,255,255,0.70)' }}>Saldo Vivo</span>
-                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '2px 9px', borderRadius: 9999, background: 'rgba(255,255,255,0.16)', color: '#fff', fontSize: 11, fontWeight: 600 }}>
-                        <span style={{ width: 6, height: 6, borderRadius: 9999, background: '#7FE0A8' }} />En tiempo real
-                      </span>
-                    </div>
+              <p style={{ margin: '0 0 30px', fontSize: 14, color: '#4A6070' }}>
+                {greetingByHour()}, <strong style={{ color: '#0D1829', fontWeight: 700 }}>{firstName}</strong>.{' '}
+                <span style={{ color: '#90A4B0' }}>Esto es lo tuyo, hoy.</span>
+              </p>
 
-                    <div style={{ fontSize: 64, fontWeight: 700, letterSpacing: '-0.05em', lineHeight: 0.92, color: '#FFFFFF', fontVariantNumeric: 'tabular-nums', marginBottom: 16 }}>
-                      {hidden ? (
-                        '$ ••••••'
-                      ) : (
-                        <>
-                          <span style={{ fontSize: 21, fontWeight: 500, color: 'rgba(255,255,255,0.55)', verticalAlign: '0.6em', marginRight: 4 }}>{currencySymbol(viewCurrency)}</span>
-                          {Number(saldoInt).toLocaleString('es-AR')}
-                          <span style={{ fontSize: 36, color: 'rgba(255,255,255,0.42)', fontWeight: 500 }}>,{saldoDec}</span>
-                        </>
-                      )}
-                    </div>
-
-                    <div style={{ display: 'flex', gap: 18, fontSize: 13, color: 'rgba(255,255,255,0.65)', marginBottom: 26 }}>
-                      <span><span style={{ color: '#fff', fontWeight: 700 }}>ARS</span>{'  '}{hidden ? '••••••' : Math.round(heroBreakdown.ARS).toLocaleString('es-AR')}</span>
-                      <span style={{ color: 'rgba(255,255,255,0.25)' }}>|</span>
-                      <span><span style={{ color: '#fff', fontWeight: 700 }}>USD</span>{'  '}{hidden ? '••••' : heroBreakdown.USD.toLocaleString('es-AR', { minimumFractionDigits: 2 })}</span>
-                    </div>
-
-                    {/* Disponible real — glass */}
-                    <button
-                      type="button"
-                      onClick={() => handleNav('cuentas')}
-                      style={{ width: '100%', textAlign: 'left', cursor: 'pointer', fontFamily: 'inherit', background: 'rgba(255,255,255,0.13)', border: '1px solid rgba(255,255,255,0.22)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)', borderRadius: 16, padding: '15px 18px', display: 'flex', alignItems: 'center', gap: 14 }}
-                    >
-                      <span style={{ width: 40, height: 40, borderRadius: 9999, flexShrink: 0, background: 'rgba(255,255,255,0.16)', border: '1px solid rgba(255,255,255,0.26)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                        <Wallet size={18} color="rgba(255,255,255,0.92)" />
-                      </span>
-                      <span style={{ flex: 1 }}>
-                        <span style={{ display: 'block', fontSize: 14, color: 'rgba(255,255,255,0.82)', fontWeight: 500 }}>Disponible real</span>
-                        <span style={{ display: 'block', fontSize: 12, color: 'rgba(255,255,255,0.55)', marginTop: 2 }}>
-                          Libre hoy: <span style={{ fontWeight: 700, color: '#fff' }}>{money(stats.reservas)}</span>
-                        </span>
-                      </span>
-                      <span style={{ fontSize: 19, fontWeight: 800, color: '#fff', fontVariantNumeric: 'tabular-nums', letterSpacing: '-0.02em' }}>{money(availableBreakdown[viewCurrency])}</span>
-                      <CaretRight weight="bold" size={13} color="rgba(255,255,255,0.5)" />
-                    </button>
-
-                    {flujoResult > 0 && ingresosMes > 0 && (
-                      <div style={{ marginTop: 16, display: 'flex', alignItems: 'center', gap: 8, fontSize: 13 }}>
-                        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, padding: '3px 9px', borderRadius: 9999, background: 'rgba(127,224,168,0.20)', color: '#C6F2D8', fontSize: 12, fontWeight: 700 }}>
-                          <ArrowUpRight weight="bold" size={11} />
-                          {hidden ? '+••%' : `+${((flujoResult / ingresosMes) * 100).toFixed(1)}%`}
-                        </span>
-                        <span style={{ color: 'rgba(255,255,255,0.65)' }}>
-                          resultado del mes · <strong style={{ color: '#fff', fontVariantNumeric: 'tabular-nums' }}>{money(flujoResult)}</strong>
-                        </span>
-                      </div>
-                    )}
-                  </div>
-
-                  {/* RIGHT — sparkline */}
-                  <div>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 12 }}>
-                      <span style={{ ...LABEL_STYLE, color: 'rgba(255,255,255,0.55)' }}>Gastos · 6 meses</span>
-                      {analyticsData?.monthlySeries.length ? (
-                        <span style={{ fontSize: 13, fontWeight: 600, color: '#fff' }}>{analyticsData.monthlySeries.length} meses</span>
-                      ) : null}
-                    </div>
-                    <svg width="100%" height="170" viewBox="0 0 360 170" preserveAspectRatio="none">
-                      <defs>
-                        <linearGradient id="heroGrad" x1="0" y1="0" x2="0" y2="1">
-                          <stop offset="0%" stopColor="rgba(255,255,255,0.24)" />
-                          <stop offset="100%" stopColor="rgba(255,255,255,0)" />
-                        </linearGradient>
-                      </defs>
-                      <g stroke="rgba(255,255,255,0.08)" strokeWidth="1">
-                        <line x1="0" y1="40" x2="360" y2="40" />
-                        <line x1="0" y1="90" x2="360" y2="90" />
-                        <line x1="0" y1="140" x2="360" y2="140" />
-                      </g>
-                      {sparklinePath ? (
-                        <>
-                          <path d={`${sparklinePath} L 360,170 L 0,170 Z`} fill="url(#heroGrad)" />
-                          <path d={sparklinePath} fill="none" stroke="rgba(255,255,255,0.85)" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-                        </>
-                      ) : (
-                        <>
-                          <path d="M 0,140 L 60,128 L 120,134 L 180,96 L 240,72 L 300,46 L 360,32 L 360,170 L 0,170 Z" fill="url(#heroGrad)" />
-                          <path d="M 0,140 L 60,128 L 120,134 L 180,96 L 240,72 L 300,46 L 360,32" fill="none" stroke="rgba(255,255,255,0.85)" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-                        </>
-                      )}
-                      {sparklineMonths.length >= 2 && (
-                        <g fontFamily="var(--font-sans)" fontSize="9.5" fill="rgba(255,255,255,0.45)">
-                          {sparklineMonths.map((label, i) => (
-                            <text key={label} x={(i / (sparklineMonths.length - 1)) * 344} y="166">{label}</text>
-                          ))}
-                        </g>
-                      )}
-                    </svg>
-                  </div>
-                </div>
+              {/* 1 · HERO: Saldo Vivo → Disponible Real + Atención ahora */}
+              <div className="hero-grid" style={{ display: 'grid', gridTemplateColumns: '1.5fr 1fr', gap: 28, alignItems: 'stretch', marginBottom: 44 }}>
+                <DesktopPanelHero
+                  stats={stats}
+                  heroBreakdown={heroBreakdown}
+                  viewCurrency={viewCurrency}
+                  hidden={hidden}
+                  money={money}
+                />
+                <DesktopAttentionPanel signals={attention} money={money} />
               </div>
 
-              {/* 2 · ATENCIÓN AHORA + PRÓXIMOS 30 DÍAS */}
-              <div className="dual" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20, marginBottom: 44 }}>
-                <AtencionAhoraModule signals={attention} />
-                <Proximos30Module events={horizon} money={money} onNav={handleNav} limit={6} />
+              {/* 2 · PRÓXIMOS 30 DÍAS */}
+              <div style={{ marginBottom: 24 }}>
+                <DesktopUpcomingTimeline events={horizon} money={money} onNav={handleNav} />
               </div>
 
-              {/* 3 · COMPROMISOS DEL MES + ACTIVIDAD RECIENTE */}
-              <div className="dual" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20, marginBottom: 44 }}>
-                <CompromisosTotalesModule compromisos={compromisos} money={money} onNav={handleNav} />
+              {/* 3 · YA TIENE DESTINO + LIQUIDEZ */}
+              <div className="dual" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24, marginBottom: 24 }}>
+                <DesktopCommitmentsPanel stats={stats} compromisos={compromisos} money={money} onNav={handleNav} />
+                <CuentasModule accounts={accountRows} money={money} onNav={handleNav} />
+              </div>
+
+              {/* 4 · PRESUPUESTO + ACTIVIDAD RECIENTE */}
+              <div className="dual" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24, marginBottom: 24 }}>
+                <PresupuestoModule budget={budget ?? null} money={money} onNav={handleNav} />
                 <MovimientosModule items={recentActivity} hidden={hidden} onNav={handleNav} limit={6} title="Actividad reciente" />
               </div>
 
-              {/* 4 · CUENTAS Y TARJETAS */}
-              <section style={{ marginBottom: 44 }}>
-                <SectionTitle>Cuentas y tarjetas</SectionTitle>
-                <div className="dual" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
-                  <TarjetasModule tarjetas={tarjetas} money={money} onNav={handleNav} />
-                  <CuentasModule accounts={accountRows} money={money} onNav={handleNav} />
-                </div>
-              </section>
-
-              {/* 5 · PLAN DEL MES + METAS */}
-              <section style={{ marginBottom: 44 }}>
-                <SectionTitle action="Ver presupuesto" onAction={() => handleNav('presupuestos')}>
-                  Plan del mes y metas
-                </SectionTitle>
-                <div className="dual" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
-                  <PresupuestoModule budget={budget ?? null} money={money} onNav={handleNav} />
-                  <MetasModule goals={dashboardGoals} activeCount={activeGoalsCount} money={money} onNav={handleNav} />
-                </div>
-              </section>
-
-              {/* 6 · INSIGHTS */}
-              <section>
-                <SectionTitle action="Ver análisis" onAction={() => handleNav('analisis')}>
-                  Cómo venís este mes
-                </SectionTitle>
-                <InsightsModule
-                  gastoTrendPct={gastoTrendPct}
-                  resultadoMes={flujoResult}
-                  tasaAhorroPct={tasaAhorroPct}
-                  money={money}
-                  onNav={handleNav}
-                />
-              </section>
+              {/* 5 · RITMO OBSERVADO */}
+              <DesktopSecondarySummary ingresosMes={ingresosMes} gastosMes={gastosMes} money={money} onNav={handleNav} />
             </>
           ) : activeNav === 'presupuestos' ? (
             <PresupuestosPage budget={budget ?? null} money={money} />
@@ -518,8 +313,7 @@ export function DesktopDashboardShell({
               }}
             />
           )}
-        </main>
-      </div>
+      </main>
     </div>
   )
 }

--- a/components/dashboard/desktop/DesktopPanelHero.tsx
+++ b/components/dashboard/desktop/DesktopPanelHero.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { currencySymbol } from './desktop-ui'
+import type { DesktopHeroStats } from './desktop-dashboard-model'
+
+type Money = (n: number, currency?: 'ARS' | 'USD') => string
+
+const LIVE_DOT = '#1A7A42'
+
+/** Barra de propiedad: el total es el Saldo Vivo; el segmento azul es lo disponible,
+ *  el segmento rayado es lo que ya tiene destino. */
+function OwnershipBar({ pctAvailable, hidden }: { pctAvailable: number; hidden: boolean }) {
+  return (
+    <div
+      aria-hidden
+      style={{
+        display: 'flex',
+        height: 10,
+        borderRadius: 6,
+        overflow: 'hidden',
+        background: 'rgba(33,120,168,0.08)',
+      }}
+    >
+      {hidden ? (
+        <div style={{ width: '100%', background: 'rgba(33,120,168,0.16)' }} />
+      ) : (
+        <>
+          {pctAvailable > 0 && (
+            <div style={{ width: `${pctAvailable * 100}%`, background: 'linear-gradient(90deg, #2178A8, #1B6A93)' }} />
+          )}
+          {pctAvailable < 1 && (
+            <div
+              style={{
+                flex: 1,
+                background:
+                  'repeating-linear-gradient(135deg, rgba(74,96,112,0.32) 0px, rgba(74,96,112,0.32) 4px, rgba(74,96,112,0.10) 4px, rgba(74,96,112,0.10) 8px)',
+              }}
+            />
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+export function DesktopPanelHero({
+  stats,
+  heroBreakdown,
+  viewCurrency,
+  hidden,
+  money,
+}: {
+  stats: DesktopHeroStats
+  heroBreakdown: Record<'ARS' | 'USD', number>
+  viewCurrency: 'ARS' | 'USD'
+  hidden: boolean
+  money: Money
+}) {
+  const [saldoInt, saldoDec] = stats.saldoVivo.toFixed(2).split('.')
+  const hasGap = stats.brecha > 0.5
+  const pctAvailable =
+    stats.saldoVivo > 0 ? Math.min(Math.max(stats.disponibleReal / stats.saldoVivo, 0), 1) : 0
+  const disponibleNegativo = stats.disponibleReal < 0
+
+  return (
+    <section style={{ padding: '10px 6px 0 0' }}>
+      {/* Champion: Saldo Vivo */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}>
+        <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.11em', textTransform: 'uppercase', color: '#2178A8' }}>
+          Tu Saldo Vivo
+        </span>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '2px 9px', borderRadius: 9999, background: 'rgba(26,122,66,0.08)', color: '#1A7A42', fontSize: 11, fontWeight: 600 }}>
+          <span style={{ width: 6, height: 6, borderRadius: 9999, background: LIVE_DOT }} />
+          En tiempo real
+        </span>
+      </div>
+
+      <div
+        style={{
+          fontSize: 68,
+          fontWeight: 800,
+          letterSpacing: '-0.05em',
+          lineHeight: 0.95,
+          color: '#0D1829',
+          fontVariantNumeric: 'tabular-nums',
+          marginBottom: 12,
+        }}
+      >
+        {hidden ? (
+          '$ ••••••'
+        ) : (
+          <>
+            <span style={{ fontSize: 24, fontWeight: 600, color: '#90A4B0', verticalAlign: '0.55em', marginRight: 6 }}>
+              {currencySymbol(viewCurrency)}
+            </span>
+            {Number(saldoInt).toLocaleString('es-AR')}
+            <span style={{ fontSize: 34, color: '#B8C9D4', fontWeight: 600 }}>,{saldoDec}</span>
+          </>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 14, fontSize: 13, color: '#90A4B0', marginBottom: 30 }}>
+        <span>La foto viva de tu plata, hoy.</span>
+        <span style={{ color: 'rgba(33,120,168,0.25)' }}>·</span>
+        <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+          <span style={{ color: '#4A6070', fontWeight: 700 }}>ARS</span>{' '}
+          {hidden ? '••••••' : Math.round(heroBreakdown.ARS).toLocaleString('es-AR')}
+        </span>
+        <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+          <span style={{ color: '#4A6070', fontWeight: 700 }}>USD</span>{' '}
+          {hidden ? '••••' : heroBreakdown.USD.toLocaleString('es-AR', { minimumFractionDigits: 2 })}
+        </span>
+      </div>
+
+      {/* Relación Saldo Vivo → Disponible Real */}
+      {stats.saldoVivo > 0 && <OwnershipBar pctAvailable={hasGap ? pctAvailable : 1} hidden={hidden} />}
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1.2fr 1fr', gap: 32, marginTop: 22 }}>
+        {/* Subhero: Disponible real */}
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+            <span style={{ width: 10, height: 10, borderRadius: 3, background: 'linear-gradient(135deg, #2178A8, #1B6A93)', flexShrink: 0 }} />
+            <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.09em', textTransform: 'uppercase', color: '#4A6070' }}>
+              Disponible real
+            </span>
+          </div>
+          <div
+            style={{
+              fontSize: 32,
+              fontWeight: 800,
+              letterSpacing: '-0.035em',
+              color: disponibleNegativo ? '#B84A12' : '#1B6A93',
+              fontVariantNumeric: 'tabular-nums',
+              lineHeight: 1,
+              marginBottom: 7,
+            }}
+          >
+            {money(stats.disponibleReal)}
+          </div>
+          <p style={{ margin: 0, fontSize: 12.5, color: '#90A4B0', lineHeight: 1.5 }}>
+            {disponibleNegativo
+              ? 'Tus consumos de tarjeta superan tu saldo de hoy.'
+              : 'Libre para usar sin pisar compromisos.'}
+          </p>
+        </div>
+
+        {/* Explicación de la brecha: ya tiene destino */}
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+            <span
+              style={{
+                width: 10,
+                height: 10,
+                borderRadius: 3,
+                flexShrink: 0,
+                background:
+                  'repeating-linear-gradient(135deg, rgba(74,96,112,0.45) 0px, rgba(74,96,112,0.45) 2px, rgba(74,96,112,0.12) 2px, rgba(74,96,112,0.12) 4px)',
+              }}
+            />
+            <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.09em', textTransform: 'uppercase', color: '#4A6070' }}>
+              Ya tiene destino
+            </span>
+          </div>
+          {hasGap ? (
+            <>
+              <div style={{ fontSize: 23, fontWeight: 700, letterSpacing: '-0.025em', color: '#4A6070', fontVariantNumeric: 'tabular-nums', lineHeight: 1, marginBottom: 7, marginTop: 5 }}>
+                {money(stats.brecha)}
+              </div>
+              <p style={{ margin: 0, fontSize: 12.5, color: '#90A4B0', lineHeight: 1.5 }}>
+                Consumos de tarjeta que todavía no pagaste.
+              </p>
+            </>
+          ) : (
+            <p style={{ margin: '5px 0 0', fontSize: 12.5, color: '#90A4B0', lineHeight: 1.5 }}>
+              Hoy nada de tu Saldo Vivo está comprometido: todo está disponible.
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/dashboard/desktop/DesktopPanelHero.tsx
+++ b/components/dashboard/desktop/DesktopPanelHero.tsx
@@ -1,14 +1,86 @@
 'use client'
 
-import { currencySymbol } from './desktop-ui'
+import { CARD_STYLE, currencySymbol, LABEL_STYLE, MAXW } from './desktop-ui'
 import type { DesktopHeroStats } from './desktop-dashboard-model'
 
 type Money = (n: number, currency?: 'ARS' | 'USD') => string
 
-const LIVE_DOT = '#1A7A42'
+/** Champion: Saldo Vivo en blanco sobre la blue-zone, como en mobile. */
+export function SaldoVivoBlueHero({
+  greeting,
+  stats,
+  heroBreakdown,
+  viewCurrency,
+  hidden,
+}: {
+  greeting: React.ReactNode
+  stats: DesktopHeroStats
+  heroBreakdown: Record<'ARS' | 'USD', number>
+  viewCurrency: 'ARS' | 'USD'
+  hidden: boolean
+}) {
+  const [saldoInt, saldoDec] = stats.saldoVivo.toFixed(2).split('.')
+
+  return (
+    <div style={{ maxWidth: MAXW, margin: '0 auto', padding: '22px 40px 56px' }}>
+      <p style={{ margin: '0 0 26px', fontSize: 14, color: 'rgba(255,255,255,0.72)' }}>{greeting}</p>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}>
+        <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.11em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.68)' }}>
+          Tu Saldo Vivo
+        </span>
+        <span
+          className="header-glass"
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '2px 9px', borderRadius: 9999, color: '#FFFFFF', fontSize: 11, fontWeight: 600 }}
+        >
+          <span style={{ width: 6, height: 6, borderRadius: 9999, background: '#7FE0A8' }} />
+          En tiempo real
+        </span>
+      </div>
+
+      <div
+        style={{
+          fontSize: 68,
+          fontWeight: 800,
+          letterSpacing: '-0.05em',
+          lineHeight: 0.95,
+          color: '#FFFFFF',
+          fontVariantNumeric: 'tabular-nums',
+          marginBottom: 12,
+        }}
+      >
+        {hidden ? (
+          '$ ••••••'
+        ) : (
+          <>
+            <span style={{ fontSize: 24, fontWeight: 600, color: 'rgba(255,255,255,0.55)', verticalAlign: '0.55em', marginRight: 6 }}>
+              {currencySymbol(viewCurrency)}
+            </span>
+            {Number(saldoInt).toLocaleString('es-AR')}
+            <span style={{ fontSize: 34, color: 'rgba(255,255,255,0.42)', fontWeight: 600 }}>,{saldoDec}</span>
+          </>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 14, fontSize: 13, color: 'rgba(255,255,255,0.62)' }}>
+        <span>La foto viva de tu plata, hoy.</span>
+        <span style={{ color: 'rgba(255,255,255,0.28)' }}>·</span>
+        <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+          <span style={{ color: '#FFFFFF', fontWeight: 700 }}>ARS</span>{' '}
+          {hidden ? '••••••' : Math.round(heroBreakdown.ARS).toLocaleString('es-AR')}
+        </span>
+        <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+          <span style={{ color: '#FFFFFF', fontWeight: 700 }}>USD</span>{' '}
+          {hidden ? '••••' : heroBreakdown.USD.toLocaleString('es-AR', { minimumFractionDigits: 2 })}
+        </span>
+      </div>
+    </div>
+  )
+}
 
 /** Barra de propiedad: el total es el Saldo Vivo; el segmento azul es lo disponible,
- *  el segmento rayado es lo que ya tiene destino. */
+ *  el segmento rayado es lo que ya tiene destino. Vive en la zona blanca para que
+ *  el azul conserve su significado. */
 function OwnershipBar({ pctAvailable, hidden }: { pctAvailable: number; hidden: boolean }) {
   return (
     <div
@@ -43,79 +115,29 @@ function OwnershipBar({ pctAvailable, hidden }: { pctAvailable: number; hidden: 
   )
 }
 
-export function DesktopPanelHero({
+/** Subhéroe: card blanca que solapa la blue-zone y explica cómo se reparte el Saldo Vivo. */
+export function DisponibleRelationCard({
   stats,
-  heroBreakdown,
-  viewCurrency,
   hidden,
   money,
 }: {
   stats: DesktopHeroStats
-  heroBreakdown: Record<'ARS' | 'USD', number>
-  viewCurrency: 'ARS' | 'USD'
   hidden: boolean
   money: Money
 }) {
-  const [saldoInt, saldoDec] = stats.saldoVivo.toFixed(2).split('.')
   const hasGap = stats.brecha > 0.5
   const pctAvailable =
     stats.saldoVivo > 0 ? Math.min(Math.max(stats.disponibleReal / stats.saldoVivo, 0), 1) : 0
   const disponibleNegativo = stats.disponibleReal < 0
 
   return (
-    <section style={{ padding: '10px 6px 0 0' }}>
-      {/* Champion: Saldo Vivo */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}>
-        <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.11em', textTransform: 'uppercase', color: '#2178A8' }}>
-          Tu Saldo Vivo
-        </span>
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '2px 9px', borderRadius: 9999, background: 'rgba(26,122,66,0.08)', color: '#1A7A42', fontSize: 11, fontWeight: 600 }}>
-          <span style={{ width: 6, height: 6, borderRadius: 9999, background: LIVE_DOT }} />
-          En tiempo real
-        </span>
-      </div>
+    <section style={{ ...CARD_STYLE, padding: '24px 26px', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ ...LABEL_STYLE, marginBottom: 16 }}>Cómo se reparte hoy</div>
 
-      <div
-        style={{
-          fontSize: 68,
-          fontWeight: 800,
-          letterSpacing: '-0.05em',
-          lineHeight: 0.95,
-          color: '#0D1829',
-          fontVariantNumeric: 'tabular-nums',
-          marginBottom: 12,
-        }}
-      >
-        {hidden ? (
-          '$ ••••••'
-        ) : (
-          <>
-            <span style={{ fontSize: 24, fontWeight: 600, color: '#90A4B0', verticalAlign: '0.55em', marginRight: 6 }}>
-              {currencySymbol(viewCurrency)}
-            </span>
-            {Number(saldoInt).toLocaleString('es-AR')}
-            <span style={{ fontSize: 34, color: '#B8C9D4', fontWeight: 600 }}>,{saldoDec}</span>
-          </>
-        )}
-      </div>
-
-      <div style={{ display: 'flex', alignItems: 'center', gap: 14, fontSize: 13, color: '#90A4B0', marginBottom: 30 }}>
-        <span>La foto viva de tu plata, hoy.</span>
-        <span style={{ color: 'rgba(33,120,168,0.25)' }}>·</span>
-        <span style={{ fontVariantNumeric: 'tabular-nums' }}>
-          <span style={{ color: '#4A6070', fontWeight: 700 }}>ARS</span>{' '}
-          {hidden ? '••••••' : Math.round(heroBreakdown.ARS).toLocaleString('es-AR')}
-        </span>
-        <span style={{ fontVariantNumeric: 'tabular-nums' }}>
-          <span style={{ color: '#4A6070', fontWeight: 700 }}>USD</span>{' '}
-          {hidden ? '••••' : heroBreakdown.USD.toLocaleString('es-AR', { minimumFractionDigits: 2 })}
-        </span>
-      </div>
-
-      {/* Relación Saldo Vivo → Disponible Real */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
       {stats.saldoVivo > 0 && <OwnershipBar pctAvailable={hasGap ? pctAvailable : 1} hidden={hidden} />}
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1.2fr 1fr', gap: 32, marginTop: 22 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '1.2fr 1fr', gap: 28, marginTop: 22 }}>
         {/* Subhero: Disponible real */}
         <div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
@@ -126,13 +148,13 @@ export function DesktopPanelHero({
           </div>
           <div
             style={{
-              fontSize: 32,
+              fontSize: 36,
               fontWeight: 800,
               letterSpacing: '-0.035em',
               color: disponibleNegativo ? '#B84A12' : '#1B6A93',
               fontVariantNumeric: 'tabular-nums',
               lineHeight: 1,
-              marginBottom: 7,
+              marginBottom: 8,
             }}
           >
             {money(stats.disponibleReal)}
@@ -163,7 +185,7 @@ export function DesktopPanelHero({
           </div>
           {hasGap ? (
             <>
-              <div style={{ fontSize: 23, fontWeight: 700, letterSpacing: '-0.025em', color: '#4A6070', fontVariantNumeric: 'tabular-nums', lineHeight: 1, marginBottom: 7, marginTop: 5 }}>
+              <div style={{ fontSize: 25, fontWeight: 700, letterSpacing: '-0.025em', color: '#4A6070', fontVariantNumeric: 'tabular-nums', lineHeight: 1, marginBottom: 8, marginTop: 8 }}>
                 {money(stats.brecha)}
               </div>
               <p style={{ margin: 0, fontSize: 12.5, color: '#90A4B0', lineHeight: 1.5 }}>
@@ -176,6 +198,7 @@ export function DesktopPanelHero({
             </p>
           )}
         </div>
+      </div>
       </div>
     </section>
   )

--- a/components/dashboard/desktop/DesktopSecondarySummary.tsx
+++ b/components/dashboard/desktop/DesktopSecondarySummary.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { ArrowRight } from '@phosphor-icons/react'
+import { BLUE, CARD_STYLE, LABEL_STYLE } from './desktop-ui'
+import type { NavId } from './desktop-chrome'
+
+type Money = (n: number, currency?: 'ARS' | 'USD') => string
+
+/** Ritmo observado del mes: solo lo percibido a hoy, sin compromisos futuros. */
+export function DesktopSecondarySummary({
+  ingresosMes,
+  gastosMes,
+  money,
+  onNav,
+}: {
+  ingresosMes: number
+  gastosMes: number
+  money: Money
+  onNav: (id: NavId) => void
+}) {
+  const resultado = ingresosMes - gastosMes
+  const stats = [
+    { key: 'ingresos', label: 'Ingresos del mes', value: ingresosMes > 0 ? `+${money(ingresosMes)}` : money(ingresosMes), color: ingresosMes > 0 ? '#1A7A42' : '#0D1829', note: 'lo que ya entró' },
+    { key: 'gastos', label: 'Gasto percibido', value: money(gastosMes), color: '#0D1829', note: 'lo que ya salió, a hoy' },
+    {
+      key: 'resultado',
+      label: 'Resultado',
+      value: money(resultado),
+      color: resultado >= 0 ? '#1A7A42' : '#B84A12',
+      note: resultado >= 0 ? 'ingresos menos gastos' : 'salió más de lo que entró',
+    },
+  ]
+
+  return (
+    <section style={{ ...CARD_STYLE, padding: '24px 26px' }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12, marginBottom: 18 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 10 }}>
+          <span style={LABEL_STYLE}>Ritmo del mes</span>
+          <span style={{ fontSize: 12.5, color: '#90A4B0' }}>Observado a hoy · no incluye compromisos futuros</span>
+        </div>
+        <button
+          type="button"
+          onClick={() => onNav('analisis')}
+          style={{ background: 'transparent', border: 0, cursor: 'pointer', padding: 0, display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 12, fontWeight: 600, color: BLUE, fontFamily: 'inherit' }}
+        >
+          Ver análisis <ArrowRight size={11} />
+        </button>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr' }}>
+        {stats.map((stat, i) => (
+          <div key={stat.key} style={{ paddingLeft: i > 0 ? 24 : 0, borderLeft: i > 0 ? '1px solid rgba(33,120,168,0.08)' : 'none' }}>
+            <div style={{ ...LABEL_STYLE, fontSize: 10, marginBottom: 8 }}>{stat.label}</div>
+            <div style={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.025em', color: stat.color, fontVariantNumeric: 'tabular-nums' }}>{stat.value}</div>
+            <div style={{ fontSize: 12, color: '#90A4B0', marginTop: 3 }}>{stat.note}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/dashboard/desktop/DesktopUpcomingTimeline.tsx
+++ b/components/dashboard/desktop/DesktopUpcomingTimeline.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { ArrowRight } from '@phosphor-icons/react'
+import { todayAR } from '@/lib/format'
+import { BLUE, CARD_STYLE, LABEL_STYLE } from './desktop-ui'
+import type { NavId } from './desktop-chrome'
+import type { HorizonEvent } from './desktop-dashboard-model'
+
+type Money = (n: number, currency?: 'ARS' | 'USD') => string
+
+const MAX_EVENTS = 5
+
+/** Cada evento explica su consecuencia sobre la caja, no solo su fecha. */
+const KIND_META: Record<
+  HorizonEvent['kind'],
+  { chip: string; chipColor: string; chipBg: string; consequence: string; sign: '' | '+'; amountCaption?: string; amountColor: string }
+> = {
+  card: {
+    chip: 'Cierre',
+    chipColor: BLUE,
+    chipBg: 'rgba(33,120,168,0.09)',
+    consequence: 'Lo que compres antes entra en este resumen.',
+    sign: '',
+    amountCaption: 'del ciclo',
+    amountColor: '#4A6070',
+  },
+  due: {
+    chip: 'Vencimiento',
+    chipColor: '#B84A12',
+    chipBg: 'rgba(184,74,18,0.10)',
+    consequence: 'Ya está contemplado en tu Disponible Real.',
+    sign: '',
+    amountCaption: 'a pagar',
+    amountColor: '#0D1829',
+  },
+  income: {
+    chip: 'Ingreso',
+    chipColor: '#1A7A42',
+    chipBg: 'rgba(26,122,66,0.10)',
+    consequence: 'Hasta que entre, no mejora la caja de hoy.',
+    sign: '+',
+    amountCaption: 'estimado',
+    amountColor: '#1A7A42',
+  },
+  instrument: {
+    chip: 'Plazo fijo',
+    chipColor: '#1A7A42',
+    chipBg: 'rgba(26,122,66,0.10)',
+    consequence: 'Ese capital vuelve a estar líquido.',
+    sign: '+',
+    amountColor: '#1A7A42',
+  },
+}
+
+function daysFromToday(dateStr: string, today: string): number {
+  const parse = (s: string) => new Date(`${s}T12:00:00-03:00`).getTime()
+  return Math.round((parse(dateStr) - parse(today)) / 86_400_000)
+}
+
+function relativeLabel(days: number): string {
+  if (days <= 0) return 'Hoy'
+  if (days === 1) return 'Mañana'
+  return `En ${days} días`
+}
+
+export function DesktopUpcomingTimeline({
+  events,
+  money,
+  onNav,
+}: {
+  events: HorizonEvent[]
+  money: Money
+  onNav: (id: NavId) => void
+}) {
+  const today = todayAR()
+  const upcoming = events
+    .map((event) => ({ event, days: daysFromToday(event.date, today) }))
+    .filter(({ days }) => days >= 0 && days <= 30)
+    .slice(0, MAX_EVENTS)
+
+  return (
+    <section style={{ ...CARD_STYLE, padding: '24px 26px' }}>
+      <style>{`
+        .timeline-rail { display: grid; grid-auto-flow: column; grid-auto-columns: 1fr; }
+        .timeline-cell + .timeline-cell { border-left: 1px solid rgba(33,120,168,0.08); }
+        @media (max-width: 1180px) {
+          .timeline-rail { grid-auto-flow: row; grid-template-columns: 1fr 1fr; }
+          .timeline-cell + .timeline-cell { border-left: 0; }
+          .timeline-cell { border-top: 1px solid rgba(33,120,168,0.08); }
+          .timeline-cell:nth-child(-n+2) { border-top: 0; }
+        }
+        @media (max-width: 720px) {
+          .timeline-rail { grid-template-columns: 1fr; }
+          .timeline-cell:nth-child(-n+2) { border-top: 1px solid rgba(33,120,168,0.08); }
+          .timeline-cell:first-child { border-top: 0; }
+        }
+      `}</style>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12, marginBottom: upcoming.length > 0 ? 18 : 12 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 10 }}>
+          <span style={LABEL_STYLE}>Próximos 30 días</span>
+          <span style={{ fontSize: 12.5, color: '#90A4B0' }}>Lo que va a mover tu caja</span>
+        </div>
+        <button
+          type="button"
+          onClick={() => onNav('analisis')}
+          style={{ background: 'transparent', border: 0, cursor: 'pointer', padding: 0, display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 12, fontWeight: 600, color: BLUE, fontFamily: 'inherit' }}
+        >
+          Ver agenda <ArrowRight size={11} />
+        </button>
+      </div>
+
+      {upcoming.length === 0 ? (
+        <p style={{ margin: 0, fontSize: 14, color: '#4A6070', lineHeight: 1.55 }}>
+          Sin eventos que muevan tu caja en los próximos 30 días.
+        </p>
+      ) : (
+        <div className="timeline-rail">
+          {upcoming.map(({ event, days }) => {
+            const meta = KIND_META[event.kind]
+            const date = new Date(`${event.date}T12:00:00-03:00`)
+            const dateLabel = date.toLocaleDateString('es-AR', { day: 'numeric', month: 'short' }).replace('.', '')
+            return (
+              <div key={event.id} className="timeline-cell" style={{ padding: '2px 18px', display: 'flex', flexDirection: 'column', gap: 7, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.05em', textTransform: 'uppercase', color: days <= 3 ? '#B84A12' : '#90A4B0' }}>
+                    {relativeLabel(days)}
+                  </span>
+                  <span style={{ fontSize: 11, color: '#B8C9D4' }}>· {dateLabel}</span>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+                  <span style={{ fontSize: 14, fontWeight: 700, color: '#0D1829', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {event.title}
+                  </span>
+                  <span style={{ padding: '2px 8px', borderRadius: 9999, fontSize: 10, fontWeight: 700, background: meta.chipBg, color: meta.chipColor, flexShrink: 0 }}>
+                    {meta.chip}
+                  </span>
+                </div>
+                {event.amount !== undefined && event.amount > 0 && (
+                  <div style={{ fontSize: 13.5, fontWeight: 700, color: meta.amountColor, fontVariantNumeric: 'tabular-nums' }}>
+                    {meta.sign}
+                    {money(event.amount, event.currency ?? 'ARS')}
+                    {meta.amountCaption && <span style={{ fontWeight: 500, color: '#90A4B0' }}> {meta.amountCaption}</span>}
+                  </div>
+                )}
+                <p style={{ margin: 0, fontSize: 12, color: '#4A6070', lineHeight: 1.45 }}>{meta.consequence}</p>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/components/dashboard/desktop/desktop-chrome.tsx
+++ b/components/dashboard/desktop/desktop-chrome.tsx
@@ -1,28 +1,9 @@
 'use client'
 
-import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
-import {
-  ArrowRight,
-  Bank,
-  Bell,
-  CalendarBlank,
-  CaretDown,
-  ChartBar,
-  ChartLineUp,
-  CreditCard,
-  Eye,
-  EyeSlash,
-  Gear,
-  House,
-  ArrowsLeftRight,
-  Sparkle,
-  Target,
-  Wallet,
-} from '@phosphor-icons/react'
-import type { Icon } from '@phosphor-icons/react'
+import { CalendarBlank, CaretDown, Eye, EyeSlash } from '@phosphor-icons/react'
 import { addMonths } from '@/lib/dates'
-import { BLUE, LABEL_STYLE, MAXW, SIDEBAR_W } from './desktop-ui'
+import { BLUE, MAXW } from './desktop-ui'
 
 export type NavId =
   | 'inicio'
@@ -38,169 +19,16 @@ type CotizacionApiData = {
   rate: number
 }
 
-const NAV_MAIN: Array<{ id: NavId; label: string; icon: Icon }> = [
-  { id: 'inicio', label: 'Inicio', icon: House },
-  { id: 'movimientos', label: 'Movimientos', icon: ArrowsLeftRight },
-  { id: 'cuentas', label: 'Cuentas', icon: Bank },
-  { id: 'tarjetas', label: 'Tarjetas', icon: CreditCard },
-  { id: 'presupuestos', label: 'Presupuestos', icon: Wallet },
-  { id: 'metas', label: 'Metas', icon: Target },
-  { id: 'instrumentos', label: 'Instrumentos', icon: ChartLineUp },
-  { id: 'analisis', label: 'Análisis', icon: ChartBar },
+const NAV_ITEMS: Array<{ id: NavId; label: string }> = [
+  { id: 'inicio', label: 'Panel' },
+  { id: 'movimientos', label: 'Movimientos' },
+  { id: 'cuentas', label: 'Cuentas' },
+  { id: 'tarjetas', label: 'Tarjetas' },
+  { id: 'presupuestos', label: 'Presupuestos' },
+  { id: 'metas', label: 'Metas' },
+  { id: 'instrumentos', label: 'Instrumentos' },
+  { id: 'analisis', label: 'Análisis' },
 ]
-
-// ─── Sidebar ─────────────────────────────────────────────────
-export function DesktopSidebar({
-  active,
-  onNav,
-  userName,
-  avatarInitial,
-  onOpenSettings,
-}: {
-  active: NavId
-  onNav: (id: NavId) => void
-  userName: string
-  avatarInitial: string
-  onOpenSettings: () => void
-}) {
-  const navBtn = (item: { id: NavId; label: string; icon: Icon }) => {
-    const isActive = item.id === active
-    const IconCmp = item.icon
-    return (
-      <button
-        key={item.id}
-        type="button"
-        onClick={() => onNav(item.id)}
-        style={{
-          position: 'relative',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 12,
-          width: '100%',
-          padding: '10px 14px 10px 18px',
-          borderRadius: 11,
-          background: isActive ? 'rgba(33,120,168,0.10)' : 'transparent',
-          border: 0,
-          cursor: 'pointer',
-          fontFamily: 'inherit',
-          fontSize: 14,
-          fontWeight: isActive ? 700 : 500,
-          color: isActive ? BLUE : '#4A6070',
-          transition: 'background 140ms, color 140ms',
-        }}
-      >
-        {isActive && (
-          <span style={{ position: 'absolute', left: 0, top: 9, bottom: 9, width: 3, borderRadius: 3, background: BLUE }} />
-        )}
-        <IconCmp weight={isActive ? 'fill' : 'regular'} size={19} color={isActive ? BLUE : '#90A4B0'} />
-        {item.label}
-      </button>
-    )
-  }
-
-  return (
-    <aside
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        bottom: 0,
-        width: SIDEBAR_W,
-        background: '#FFFFFF',
-        borderRight: '1px solid rgba(33,120,168,0.10)',
-        display: 'flex',
-        flexDirection: 'column',
-        zIndex: 60,
-      }}
-    >
-      {/* Logo */}
-      <Link
-        href="/web"
-        style={{ padding: '24px 24px 22px', display: 'flex', alignItems: 'center', gap: 9, textDecoration: 'none' }}
-      >
-        <span style={{ fontSize: 23, fontWeight: 800, letterSpacing: '-0.045em', color: '#0D1829' }}>
-          gota<span style={{ color: BLUE }}>.</span>
-        </span>
-      </Link>
-
-      {/* Main nav */}
-      <nav style={{ display: 'flex', flexDirection: 'column', gap: 2, padding: '0 12px', flex: 1, overflowY: 'auto' }}>
-        <div style={{ ...LABEL_STYLE, fontSize: 10, padding: '6px 18px 8px' }}>General</div>
-        {NAV_MAIN.slice(0, 4).map(navBtn)}
-        <div style={{ ...LABEL_STYLE, fontSize: 10, padding: '18px 18px 8px' }}>Planificación</div>
-        {NAV_MAIN.slice(4).map(navBtn)}
-      </nav>
-
-      {/* Footer: config + user */}
-      <div style={{ padding: '12px', borderTop: '1px solid rgba(33,120,168,0.08)' }}>
-        <button
-          type="button"
-          onClick={onOpenSettings}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 12,
-            width: '100%',
-            padding: '10px 14px 10px 18px',
-            borderRadius: 11,
-            background: 'transparent',
-            border: 0,
-            cursor: 'pointer',
-            fontFamily: 'inherit',
-            fontSize: 14,
-            fontWeight: 500,
-            color: '#4A6070',
-          }}
-        >
-          <Gear size={19} color="#90A4B0" />
-          Configuración
-        </button>
-        <button
-          type="button"
-          onClick={onOpenSettings}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 11,
-            width: '100%',
-            padding: '10px 12px',
-            marginTop: 4,
-            borderRadius: 11,
-            background: 'transparent',
-            border: 0,
-            cursor: 'pointer',
-            fontFamily: 'inherit',
-            textAlign: 'left',
-          }}
-        >
-          <span
-            style={{
-              width: 34,
-              height: 34,
-              borderRadius: 9999,
-              flexShrink: 0,
-              background: 'linear-gradient(135deg, #2178A8 0%, #1B7E9E 100%)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              color: '#fff',
-              fontSize: 13,
-              fontWeight: 700,
-            }}
-          >
-            {avatarInitial}
-          </span>
-          <span style={{ minWidth: 0 }}>
-            <span style={{ display: 'block', fontSize: 13, fontWeight: 700, color: '#0D1829', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {userName}
-            </span>
-            <span style={{ display: 'block', fontSize: 11, color: '#90A4B0' }}>Plan Personal</span>
-          </span>
-        </button>
-      </div>
-    </aside>
-  )
-}
 
 // ─── Period (month) selector ─────────────────────────────────
 function formatMonthLabel(ym: string): string {
@@ -236,7 +64,7 @@ function MonthSelector({ selectedMonth, onSelectMonth }: { selectedMonth: string
           gap: 7,
           padding: '7px 12px',
           borderRadius: 9999,
-          background: open ? 'rgba(33,120,168,0.10)' : '#FFFFFF',
+          background: open ? 'rgba(33,120,168,0.10)' : 'transparent',
           border: '1px solid rgba(33,120,168,0.14)',
           cursor: 'pointer',
           fontFamily: 'inherit',
@@ -305,139 +133,142 @@ function MonthSelector({ selectedMonth, onSelectMonth }: { selectedMonth: string
   )
 }
 
-// ─── Topbar (utility bar inside main column) ─────────────────
-export function DesktopTopbar({
-  greeting,
+// ─── Topnav: wordmark + navegación + contexto (mes, USD, ojo, avatar) ──
+export function DesktopTopnav({
+  active,
+  onNav,
   hidden,
   onToggleHidden,
   quote,
   selectedMonth,
   onSelectMonth,
+  avatarInitial,
+  onOpenSettings,
 }: {
-  greeting: React.ReactNode
+  active: NavId
+  onNav: (id: NavId) => void
   hidden: boolean
   onToggleHidden: () => void
   quote: CotizacionApiData | null
   selectedMonth: string
   onSelectMonth: (month: string) => void
+  avatarInitial: string
+  onOpenSettings: () => void
 }) {
-  const [val, setVal] = useState('')
-  const hasText = val.trim().length > 0
   return (
     <header
       style={{
         position: 'sticky',
         top: 0,
         zIndex: 50,
-        background: 'rgba(248,251,253,0.86)',
+        background: 'rgba(255,255,255,0.88)',
         backdropFilter: 'blur(10px)',
         WebkitBackdropFilter: 'blur(10px)',
-        borderBottom: '1px solid rgba(33,120,168,0.08)',
+        borderBottom: '1px solid rgba(33,120,168,0.09)',
       }}
     >
-      <div style={{ maxWidth: MAXW, margin: '0 auto', padding: '0 40px', height: 64, display: 'flex', alignItems: 'center', gap: 16 }}>
-        <div style={{ flex: 1, minWidth: 0, fontSize: 14, color: '#4A6070' }}>{greeting}</div>
-
-        {/* SmartInput */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-            padding: '6px 6px 6px 16px',
-            background: '#FFFFFF',
-            border: hasText ? '1px solid rgba(33,120,168,0.32)' : '1px solid rgba(33,120,168,0.12)',
-            borderRadius: 9999,
-            width: 300,
-            transition: 'border-color 150ms',
-            flexShrink: 0,
-          }}
+      <style>{`
+        @media (max-width: 1320px) { .topnav-quote { display: none !important; } }
+        @media (max-width: 1180px) { .topnav-nav { gap: 0 !important; } .topnav-nav button { padding: 0 8px !important; } }
+      `}</style>
+      <div style={{ maxWidth: MAXW, margin: '0 auto', padding: '0 40px', height: 62, display: 'flex', alignItems: 'stretch', gap: 24 }}>
+        <button
+          type="button"
+          onClick={() => onNav('inicio')}
+          style={{ display: 'flex', alignItems: 'center', background: 'transparent', border: 0, cursor: 'pointer', padding: 0, fontFamily: 'inherit', flexShrink: 0 }}
         >
-          <input
-            value={val}
-            onChange={(e) => setVal(e.target.value)}
-            placeholder="café 2500 hoy…"
-            aria-label="Carga rápida con IA"
-            style={{ flex: 1, border: 0, outline: 'none', background: 'transparent', fontSize: 13, color: '#0D1829', fontFamily: 'inherit' }}
-          />
-          {!hasText && (
-            <span
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-                padding: '3px 8px',
-                borderRadius: 9999,
-                background: 'rgba(33,120,168,0.08)',
-                color: BLUE,
-                fontSize: 11,
-                fontWeight: 600,
-                flexShrink: 0,
-              }}
-            >
-              <Sparkle weight="bold" size={10} />
-              IA
+          <span style={{ fontSize: 22, fontWeight: 800, letterSpacing: '-0.045em', color: '#0D1829' }}>
+            gota<span style={{ color: BLUE }}>.</span>
+          </span>
+        </button>
+
+        <nav className="topnav-nav" style={{ display: 'flex', alignItems: 'stretch', gap: 4, minWidth: 0, overflowX: 'auto' }}>
+          {NAV_ITEMS.map((item) => {
+            const isActive = item.id === active
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => onNav(item.id)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '0 11px',
+                  background: 'transparent',
+                  border: 0,
+                  borderBottom: isActive ? `2px solid ${BLUE}` : '2px solid transparent',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  fontSize: 13.5,
+                  fontWeight: isActive ? 700 : 500,
+                  color: isActive ? BLUE : '#4A6070',
+                  whiteSpace: 'nowrap',
+                  transition: 'color 140ms',
+                }}
+              >
+                {item.label}
+              </button>
+            )
+          })}
+        </nav>
+
+        <div style={{ flex: 1 }} />
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0 }}>
+          <MonthSelector selectedMonth={selectedMonth} onSelectMonth={onSelectMonth} />
+
+          {quote && (
+            <span className="topnav-quote" style={{ fontSize: 12, color: '#90A4B0', whiteSpace: 'nowrap' }}>
+              USD oficial <span style={{ color: '#4A6070', fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{quote.rate.toLocaleString('es-AR')}</span>
             </span>
           )}
+
           <button
             type="button"
-            aria-label="Enviar"
+            onClick={onToggleHidden}
+            aria-label={hidden ? 'Mostrar montos' : 'Ocultar montos'}
+            title={hidden ? 'Mostrar montos' : 'Ocultar montos'}
             style={{
-              width: 28,
-              height: 28,
+              width: 34,
+              height: 34,
+              borderRadius: 9999,
+              background: hidden ? 'rgba(33,120,168,0.10)' : 'transparent',
+              border: '1px solid rgba(33,120,168,0.14)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: hidden ? BLUE : '#90A4B0',
+            }}
+          >
+            {hidden ? <EyeSlash size={16} /> : <Eye size={16} />}
+          </button>
+
+          <button
+            type="button"
+            onClick={onOpenSettings}
+            aria-label="Configuración"
+            title="Configuración"
+            style={{
+              width: 34,
+              height: 34,
               borderRadius: 9999,
               flexShrink: 0,
-              background: hasText ? BLUE : 'rgba(15,30,60,0.06)',
+              background: 'linear-gradient(135deg, #2178A8 0%, #1B7E9E 100%)',
               border: 0,
               cursor: 'pointer',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
+              color: '#fff',
+              fontSize: 13,
+              fontWeight: 700,
+              fontFamily: 'inherit',
             }}
           >
-            <ArrowRight weight="bold" size={12} color={hasText ? '#fff' : '#90A4B0'} />
+            {avatarInitial}
           </button>
         </div>
-
-        <MonthSelector selectedMonth={selectedMonth} onSelectMonth={onSelectMonth} />
-
-        {quote && (
-          <span style={{ fontSize: 12, color: '#90A4B0', whiteSpace: 'nowrap', flexShrink: 0 }}>
-            ARS · USD <span style={{ color: BLUE, fontWeight: 700 }}>{quote.rate.toLocaleString('es-AR')}</span>
-          </span>
-        )}
-
-        <button
-          type="button"
-          onClick={onToggleHidden}
-          title={hidden ? 'Mostrar montos' : 'Ocultar montos'}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 6,
-            padding: '7px 12px',
-            borderRadius: 9999,
-            flexShrink: 0,
-            background: hidden ? 'rgba(33,120,168,0.10)' : 'transparent',
-            border: '1px solid rgba(33,120,168,0.14)',
-            cursor: 'pointer',
-            fontFamily: 'inherit',
-            fontSize: 12,
-            fontWeight: 600,
-            color: hidden ? BLUE : '#90A4B0',
-          }}
-        >
-          {hidden ? <EyeSlash size={15} /> : <Eye size={15} />}
-          {hidden ? 'Oculto' : 'Visible'}
-        </button>
-
-        <button
-          type="button"
-          aria-label="Notificaciones"
-          style={{ position: 'relative', background: 'transparent', border: 0, cursor: 'pointer', padding: 7, display: 'flex', flexShrink: 0 }}
-        >
-          <Bell size={17} color="#90A4B0" />
-        </button>
       </div>
     </header>
   )

--- a/components/dashboard/desktop/desktop-chrome.tsx
+++ b/components/dashboard/desktop/desktop-chrome.tsx
@@ -64,19 +64,19 @@ function MonthSelector({ selectedMonth, onSelectMonth }: { selectedMonth: string
           gap: 7,
           padding: '7px 12px',
           borderRadius: 9999,
-          background: open ? 'rgba(33,120,168,0.10)' : 'transparent',
-          border: '1px solid rgba(33,120,168,0.14)',
+          background: open ? 'rgba(255,255,255,0.26)' : 'rgba(255,255,255,0.14)',
+          border: '1px solid rgba(255,255,255,0.24)',
           cursor: 'pointer',
           fontFamily: 'inherit',
           fontSize: 13,
           fontWeight: 700,
-          color: '#0D1829',
+          color: '#FFFFFF',
           whiteSpace: 'nowrap',
         }}
       >
-        <CalendarBlank size={15} color={BLUE} />
+        <CalendarBlank size={15} color="rgba(255,255,255,0.85)" />
         {formatMonthLabel(current)}
-        <CaretDown weight="bold" size={11} color="#90A4B0" style={{ transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 140ms' }} />
+        <CaretDown weight="bold" size={11} color="rgba(255,255,255,0.65)" style={{ transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 140ms' }} />
       </button>
       {open && (
         <div
@@ -134,6 +134,7 @@ function MonthSelector({ selectedMonth, onSelectMonth }: { selectedMonth: string
 }
 
 // ─── Topnav: wordmark + navegación + contexto (mes, USD, ojo, avatar) ──
+// Se renderiza sobre la blue-zone (S5): texto blanco y pills header-glass.
 export function DesktopTopnav({
   active,
   onNav,
@@ -156,29 +157,19 @@ export function DesktopTopnav({
   onOpenSettings: () => void
 }) {
   return (
-    <header
-      style={{
-        position: 'sticky',
-        top: 0,
-        zIndex: 50,
-        background: 'rgba(255,255,255,0.88)',
-        backdropFilter: 'blur(10px)',
-        WebkitBackdropFilter: 'blur(10px)',
-        borderBottom: '1px solid rgba(33,120,168,0.09)',
-      }}
-    >
+    <header>
       <style>{`
         @media (max-width: 1320px) { .topnav-quote { display: none !important; } }
         @media (max-width: 1180px) { .topnav-nav { gap: 0 !important; } .topnav-nav button { padding: 0 8px !important; } }
       `}</style>
-      <div style={{ maxWidth: MAXW, margin: '0 auto', padding: '0 40px', height: 62, display: 'flex', alignItems: 'stretch', gap: 24 }}>
+      <div style={{ maxWidth: MAXW, margin: '0 auto', padding: '0 40px', height: 64, display: 'flex', alignItems: 'stretch', gap: 24 }}>
         <button
           type="button"
           onClick={() => onNav('inicio')}
           style={{ display: 'flex', alignItems: 'center', background: 'transparent', border: 0, cursor: 'pointer', padding: 0, fontFamily: 'inherit', flexShrink: 0 }}
         >
-          <span style={{ fontSize: 22, fontWeight: 800, letterSpacing: '-0.045em', color: '#0D1829' }}>
-            gota<span style={{ color: BLUE }}>.</span>
+          <span style={{ fontSize: 22, fontWeight: 800, letterSpacing: '-0.045em', color: '#FFFFFF' }}>
+            gota<span style={{ color: 'rgba(255,255,255,0.55)' }}>.</span>
           </span>
         </button>
 
@@ -196,12 +187,12 @@ export function DesktopTopnav({
                   padding: '0 11px',
                   background: 'transparent',
                   border: 0,
-                  borderBottom: isActive ? `2px solid ${BLUE}` : '2px solid transparent',
+                  borderBottom: isActive ? '2px solid #FFFFFF' : '2px solid transparent',
                   cursor: 'pointer',
                   fontFamily: 'inherit',
                   fontSize: 13.5,
                   fontWeight: isActive ? 700 : 500,
-                  color: isActive ? BLUE : '#4A6070',
+                  color: isActive ? '#FFFFFF' : 'rgba(255,255,255,0.72)',
                   whiteSpace: 'nowrap',
                   transition: 'color 140ms',
                 }}
@@ -218,8 +209,8 @@ export function DesktopTopnav({
           <MonthSelector selectedMonth={selectedMonth} onSelectMonth={onSelectMonth} />
 
           {quote && (
-            <span className="topnav-quote" style={{ fontSize: 12, color: '#90A4B0', whiteSpace: 'nowrap' }}>
-              USD oficial <span style={{ color: '#4A6070', fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{quote.rate.toLocaleString('es-AR')}</span>
+            <span className="topnav-quote" style={{ fontSize: 12, color: 'rgba(255,255,255,0.68)', whiteSpace: 'nowrap' }}>
+              USD oficial <span style={{ color: '#FFFFFF', fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{quote.rate.toLocaleString('es-AR')}</span>
             </span>
           )}
 
@@ -232,13 +223,13 @@ export function DesktopTopnav({
               width: 34,
               height: 34,
               borderRadius: 9999,
-              background: hidden ? 'rgba(33,120,168,0.10)' : 'transparent',
-              border: '1px solid rgba(33,120,168,0.14)',
+              background: hidden ? 'rgba(255,255,255,0.28)' : 'rgba(255,255,255,0.10)',
+              border: '1px solid rgba(255,255,255,0.24)',
               cursor: 'pointer',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              color: hidden ? BLUE : '#90A4B0',
+              color: hidden ? '#FFFFFF' : 'rgba(255,255,255,0.82)',
             }}
           >
             {hidden ? <EyeSlash size={16} /> : <Eye size={16} />}
@@ -254,8 +245,8 @@ export function DesktopTopnav({
               height: 34,
               borderRadius: 9999,
               flexShrink: 0,
-              background: 'linear-gradient(135deg, #2178A8 0%, #1B7E9E 100%)',
-              border: 0,
+              background: 'rgba(255,255,255,0.16)',
+              border: '1px solid rgba(255,255,255,0.34)',
               cursor: 'pointer',
               display: 'flex',
               alignItems: 'center',

--- a/components/dashboard/desktop/desktop-dashboard-model.ts
+++ b/components/dashboard/desktop/desktop-dashboard-model.ts
@@ -19,6 +19,10 @@ export type AttentionSignal = {
   detail: string
   tone: 'high' | 'medium' | 'low'
   dateLabel: string
+  /** Monto real que respalda la señal (se renderiza con el formato oculto/visible). */
+  amount?: number
+  amountCaption?: string
+  currency?: 'ARS' | 'USD'
 }
 
 export type HorizonEvent = {
@@ -72,13 +76,6 @@ function relativeDayLabel(date: string, today = todayAR()): string {
     return raw.charAt(0).toUpperCase() + raw.slice(1)
   }
   return formatShortDate(date)
-}
-
-function monthLabel(month: string) {
-  const raw = new Date(`${month}-15T12:00:00-03:00`).toLocaleDateString('es-AR', {
-    month: 'long',
-  })
-  return raw.charAt(0).toUpperCase() + raw.slice(1)
 }
 
 function recurringIncomeLabel(recurring: RecurringIncome) {
@@ -141,12 +138,17 @@ export function buildAttentionSignals(params: {
     .sort((a, b) => (a.daysUntilClosing ?? 99) - (b.daysUntilClosing ?? 99))[0]
 
   if (nearestClosing && nearestClosing.daysUntilClosing !== null) {
+    const days = nearestClosing.daysUntilClosing
+    const when = days === 0 ? 'cierra hoy' : days === 1 ? 'cierra mañana' : `cierra en ${days} días`
     items.push({
       id: `closing-${nearestClosing.id}`,
-      title: `${nearestClosing.name} cierra en ${nearestClosing.daysUntilClosing} d${nearestClosing.daysUntilClosing === 1 ? 'ía' : 'ías'}`,
-      detail: 'Conviene cuidar consumos antes del próximo corte.',
-      tone: nearestClosing.daysUntilClosing <= 3 ? 'high' : 'medium',
+      title: `${nearestClosing.name} ${when}`,
+      detail: 'Si comprás ahora, entra en el próximo resumen.',
+      tone: days <= 3 ? 'high' : 'medium',
       dateLabel: 'Próximo cierre',
+      amount: nearestClosing.currentSpend > 0 ? nearestClosing.currentSpend : undefined,
+      amountCaption: 'llevás del ciclo',
+      currency: 'ARS',
     })
   }
 
@@ -155,15 +157,18 @@ export function buildAttentionSignals(params: {
     .sort((a, b) => (a.daysUntilDue ?? 999) - (b.daysUntilDue ?? 999))[0]
 
   if (nearestDue?.dueDate && nearestDue.daysUntilDue !== null && nearestDue.daysUntilDue <= 7) {
+    const days = nearestDue.daysUntilDue
+    const when =
+      days < 0 ? 'ya venció' : days === 0 ? 'vence hoy' : days === 1 ? 'vence mañana' : `vence en ${days} días`
     items.push({
       id: `due-${nearestDue.id}`,
-      title:
-        nearestDue.daysUntilDue < 0
-          ? `${nearestDue.name} ya venció`
-          : `${nearestDue.name} vence en ${nearestDue.daysUntilDue} d${nearestDue.daysUntilDue === 1 ? 'ía' : 'ías'}`,
-      detail: 'Tenés un compromiso próximo que ya afecta tu margen disponible.',
-      tone: nearestDue.daysUntilDue <= 1 ? 'high' : 'medium',
+      title: `${nearestDue.name} ${when}`,
+      detail: 'El pago ya está descontado de tu Disponible Real.',
+      tone: days <= 1 ? 'high' : 'medium',
       dateLabel: formatShortDate(nearestDue.dueDate),
+      amount: nearestDue.debtTotal > 0 ? nearestDue.debtTotal : undefined,
+      amountCaption: 'a pagar',
+      currency: 'ARS',
     })
   }
 
@@ -173,8 +178,8 @@ export function buildAttentionSignals(params: {
     if (idleDays >= 3) {
       items.push({
         id: 'stale-log',
-        title: `Llevás ${idleDays} días sin registrar`,
-        detail: 'La lectura puede quedarse corta si faltan movimientos recientes.',
+        title: `Hace ${idleDays} días que no registrás`,
+        detail: 'La lectura puede quedar corta si faltan movimientos recientes.',
         tone: idleDays >= 5 ? 'medium' : 'low',
         dateLabel: formatShortDate(lastMovement),
       })

--- a/components/dashboard/desktop/desktop-modules.tsx
+++ b/components/dashboard/desktop/desktop-modules.tsx
@@ -1,50 +1,20 @@
 'use client'
 
-import type { CSSProperties } from 'react'
-import {
-  ArrowDownLeft,
-  ArrowRight,
-  ArrowsLeftRight,
-  ArrowUpRight,
-  CreditCard,
-  LockSimple,
-  MinusCircle,
-  PencilSimple,
-  PlusCircle,
-  Receipt,
-  Target,
-  TrendDown,
-  TrendUp,
-  Warning,
-} from '@phosphor-icons/react'
+import { ArrowDownLeft, ArrowRight, ArrowsLeftRight } from '@phosphor-icons/react'
 import type { BudgetSnapshot, BudgetStatus } from '@/lib/budgets/types'
-import type { GoalWithMetrics, GoalPaceStatus } from '@/lib/goals/types'
-import type { Instrument } from '@/types/database'
-import type { CompromisosData } from '@/lib/analytics/computeCompromisos'
 import { BLUE, CARD_STYLE, CatSquare, LABEL_STYLE } from './desktop-ui'
 import type { NavId } from './desktop-chrome'
-import type { AttentionSignal, HorizonEvent, RecentActivityItem } from './desktop-dashboard-model'
+import type { RecentActivityItem } from './desktop-dashboard-model'
 
 type Money = (n: number, currency?: 'ARS' | 'USD') => string
-type TarjetaItem = CompromisosData['tarjetas'][number]
 
 export type AccountRow = { id: string; name: string; type: string; isPrimary: boolean; saldo: number; color: string }
-
-const SOFT_BG = '#F8FBFD'
 
 const BUDGET_STATUS: Record<BudgetStatus, { label: string; color: string; amountColor: string; bg: string; bar: string }> = {
   on_track: { label: 'En línea', color: '#4A6070', amountColor: '#0D1829', bg: 'rgba(74,96,112,0.10)', bar: BLUE },
   near_limit: { label: 'Al límite', color: '#B84A12', amountColor: '#B84A12', bg: 'rgba(184,74,18,0.10)', bar: '#B84A12' },
   over_budget: { label: 'Pasado', color: '#A61E1E', amountColor: '#A61E1E', bg: 'rgba(166,30,30,0.09)', bar: '#A61E1E' },
   ahead_of_pace: { label: 'Con aire', color: BLUE, amountColor: '#0D1829', bg: 'rgba(33,120,168,0.09)', bar: BLUE },
-}
-
-const GOAL_PACE: Record<GoalPaceStatus, { label: string; color: string }> = {
-  on_track: { label: 'En ritmo', color: '#1A7A42' },
-  behind: { label: 'Atrasada', color: '#B84A12' },
-  completed: { label: 'Cumplida', color: '#1A7A42' },
-  no_date: { label: 'Sin fecha', color: '#4A6070' },
-  paused: { label: 'Pausada', color: '#90A4B0' },
 }
 
 // ─── Module card wrapper ─────────────────────────────────────
@@ -97,7 +67,7 @@ function ModuleCard({
   )
 }
 
-const bigNum: CSSProperties = { fontSize: 26, fontWeight: 700, letterSpacing: '-0.03em', color: '#0D1829' }
+const bigNum: React.CSSProperties = { fontSize: 26, fontWeight: 700, letterSpacing: '-0.03em', color: '#0D1829' }
 
 // ─── PRESUPUESTO (compact) ───────────────────────────────────
 export function PresupuestoModule({
@@ -113,7 +83,7 @@ export function PresupuestoModule({
     return (
       <ModuleCard title="Presupuesto mensual" action="Armar plan" onAction={() => onNav('presupuestos')}>
         <p style={{ fontSize: 14, color: '#4A6070', lineHeight: 1.6, margin: 0 }}>
-          Todavía no armaste un presupuesto. Definí un marco por categoría para seguir el mes con más claridad.
+          Falta presupuesto para comparar tu ritmo por categoría. Definí un marco simple para seguir el mes con más claridad.
         </p>
       </ModuleCard>
     )
@@ -167,136 +137,7 @@ export function PresupuestoModule({
   )
 }
 
-// ─── METAS (compact, real) ───────────────────────────────────
-export function MetasModule({
-  goals,
-  activeCount,
-  money,
-  onNav,
-}: {
-  goals: GoalWithMetrics[]
-  activeCount: number
-  money: Money
-  onNav: (id: NavId) => void
-}) {
-  if (goals.length === 0) {
-    return (
-      <ModuleCard title="Metas" action="Crear meta" onAction={() => onNav('metas')}>
-        <p style={{ fontSize: 14, color: '#4A6070', lineHeight: 1.6, margin: 0 }}>
-          Todavía no tenés metas. Creá objetivos y registrá aportes para seguir tu progreso.
-        </p>
-      </ModuleCard>
-    )
-  }
-  const saved = goals.reduce((s, g) => s + g.currentAmount, 0)
-  const target = goals.reduce((s, g) => s + g.targetAmount, 0)
-  const pct = target > 0 ? saved / target : 0
-  const ccy = goals[0].currency
-  return (
-    <ModuleCard
-      title="Metas"
-      tag={`${activeCount} activa${activeCount !== 1 ? 's' : ''}`}
-      tagTone="primary"
-      action="Ver metas"
-      onAction={() => onNav('metas')}
-    >
-      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 4 }}>
-        <span style={bigNum}>{money(saved, ccy)}</span>
-        <span style={{ fontSize: 15, color: '#90A4B0', fontWeight: 500 }}>de {money(target, ccy)}</span>
-      </div>
-      <div style={{ fontSize: 13, color: '#4A6070', marginBottom: 14 }}>
-        {Math.round(pct * 100)}% del total objetivo alcanzado
-      </div>
-      <div style={{ height: 8, borderRadius: 4, background: 'rgba(33,120,168,0.09)', overflow: 'hidden', marginBottom: 18 }}>
-        <div style={{ width: `${Math.min(pct, 1) * 100}%`, height: '100%', background: 'linear-gradient(90deg,#2178A8,#1B7E9E)', borderRadius: 4 }} />
-      </div>
-
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-        {goals.map((g) => {
-          const gp = g.progressPct
-          const pace = GOAL_PACE[g.paceStatus]
-          return (
-            <div key={g.id} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-              <span style={{ width: 32, height: 32, borderRadius: 10, flexShrink: 0, background: 'rgba(33,120,168,0.09)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 15, lineHeight: 1 }}>
-                {g.emoji ? g.emoji : <Target size={16} color={BLUE} />}
-              </span>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 5, gap: 8 }}>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: '#0D1829', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{g.name}</span>
-                  <span style={{ fontSize: 12, fontWeight: 700, color: pace.color, flexShrink: 0 }}>{Math.round(gp * 100)}%</span>
-                </div>
-                <div style={{ height: 5, borderRadius: 3, background: 'rgba(33,120,168,0.09)', overflow: 'hidden' }}>
-                  <div style={{ width: `${Math.min(gp, 1) * 100}%`, height: '100%', background: g.paceStatus === 'behind' ? '#B84A12' : BLUE, borderRadius: 3 }} />
-                </div>
-              </div>
-            </div>
-          )
-        })}
-      </div>
-    </ModuleCard>
-  )
-}
-
-// ─── TARJETAS (próximos cierres / consumo) ───────────────────
-export function TarjetasModule({
-  tarjetas,
-  money,
-  onNav,
-}: {
-  tarjetas: TarjetaItem[]
-  money: Money
-  onNav: (id: NavId) => void
-}) {
-  if (tarjetas.length === 0) {
-    return (
-      <ModuleCard title="Tarjetas" action="Ver tarjetas" onAction={() => onNav('tarjetas')}>
-        <p style={{ fontSize: 14, color: '#4A6070', margin: 0 }}>Sin tarjetas activas.</p>
-      </ModuleCard>
-    )
-  }
-  const sorted = [...tarjetas].sort((a, b) => (a.daysUntilClosing ?? 99) - (b.daysUntilClosing ?? 99))
-  const next = sorted[0]
-  return (
-    <ModuleCard
-      title="Tarjetas"
-      tag={next.daysUntilClosing != null ? `cierra en ${next.daysUntilClosing} días` : undefined}
-      tagTone={(next.daysUntilClosing ?? 99) <= 5 ? 'warn' : 'primary'}
-      action="Ver tarjetas"
-      onAction={() => onNav('tarjetas')}
-    >
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-        {sorted.map((c) => {
-          const progress = Math.max(0.05, Math.min(0.97, (30 - (c.daysUntilClosing ?? 15)) / 30))
-          return (
-            <div key={c.id} style={{ padding: '14px 16px', borderRadius: 14, background: SOFT_BG, border: '1px solid rgba(33,120,168,0.07)' }}>
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
-                <span style={{ display: 'flex', alignItems: 'center', gap: 9, fontSize: 14, fontWeight: 700, color: '#0D1829' }}>
-                  <CreditCard weight="light" size={17} color={BLUE} />
-                  {c.name}
-                </span>
-                {c.dueDate && (
-                  <span style={{ fontSize: 11, color: '#90A4B0' }}>
-                    vence {new Date(`${c.dueDate}T12:00:00-03:00`).toLocaleDateString('es-AR', { day: 'numeric', month: 'short' })}
-                  </span>
-                )}
-              </div>
-              <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 8 }}>
-                <span style={{ fontSize: 12, color: '#4A6070' }}>Consumo del ciclo</span>
-                <span style={{ fontSize: 15, fontWeight: 800, color: '#0D1829' }}>{money(c.currentSpend, 'ARS')}</span>
-              </div>
-              <div style={{ position: 'relative', height: 5, borderRadius: 3, background: 'rgba(33,120,168,0.10)' }}>
-                <div style={{ width: `${Math.round(progress * 100)}%`, height: '100%', background: '#0D1829', borderRadius: 3 }} />
-                <div style={{ position: 'absolute', left: `${Math.round(progress * 100)}%`, top: -3, width: 2, height: 11, background: BLUE, transform: 'translateX(-50%)' }} />
-              </div>
-            </div>
-          )
-        })}
-      </div>
-    </ModuleCard>
-  )
-}
-
-// ─── CUENTAS (resumen por cuenta) ────────────────────────────
+// ─── CUENTAS (dónde está la plata) ───────────────────────────
 export function CuentasModule({
   accounts,
   money,
@@ -308,9 +149,9 @@ export function CuentasModule({
 }) {
   const total = accounts.reduce((s, a) => s + a.saldo, 0)
   return (
-    <ModuleCard title="Cuentas" tag={`${accounts.length}`} tagTone="muted" action="Ver cuentas" onAction={() => onNav('cuentas')}>
-      <div style={{ marginBottom: 6, fontSize: 24, fontWeight: 700, letterSpacing: '-0.025em', color: '#0D1829' }}>{money(total)}</div>
-      <div style={{ fontSize: 12, color: '#90A4B0', marginBottom: 16 }}>Saldo total sincronizado</div>
+    <ModuleCard title="Liquidez" tag={`${accounts.length} cuenta${accounts.length !== 1 ? 's' : ''}`} tagTone="muted" action="Ver cuentas" onAction={() => onNav('cuentas')}>
+      <div style={{ marginBottom: 6, fontSize: 24, fontWeight: 700, letterSpacing: '-0.025em', color: '#0D1829', fontVariantNumeric: 'tabular-nums' }}>{money(total)}</div>
+      <div style={{ fontSize: 12, color: '#90A4B0', marginBottom: 16 }}>Dónde está tu plata hoy</div>
       <div>
         {accounts.map((a, i) => (
           <div key={a.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '11px 0', borderTop: i > 0 ? '1px solid rgba(33,120,168,0.07)' : 'none' }}>
@@ -324,7 +165,7 @@ export function CuentasModule({
               </div>
               <div style={{ fontSize: 11, color: '#90A4B0' }}>{a.type}</div>
             </div>
-            <span style={{ fontSize: 14, fontWeight: 700, color: '#0D1829', flexShrink: 0 }}>{money(a.saldo)}</span>
+            <span style={{ fontSize: 14, fontWeight: 700, color: '#0D1829', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>{money(a.saldo)}</span>
           </div>
         ))}
       </div>
@@ -332,54 +173,7 @@ export function CuentasModule({
   )
 }
 
-// ─── INSTRUMENTOS / rendimientos ─────────────────────────────
-export function InstrumentosModule({
-  instruments,
-  money,
-  onNav,
-}: {
-  instruments: Instrument[]
-  money: Money
-  onNav: (id: NavId) => void
-}) {
-  if (instruments.length === 0) {
-    return (
-      <ModuleCard title="Instrumentos" action="Ver instrumentos" onAction={() => onNav('instrumentos')}>
-        <p style={{ fontSize: 14, color: '#4A6070', margin: 0 }}>No hay instrumentos activos.</p>
-      </ModuleCard>
-    )
-  }
-  const total = instruments.reduce((s, i) => s + i.amount, 0)
-  return (
-    <ModuleCard title="Instrumentos" tag={`${instruments.length} activos`} tagTone="primary" action="Ver instrumentos" onAction={() => onNav('instrumentos')}>
-      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 4 }}>
-        <span style={{ fontSize: 24, fontWeight: 700, letterSpacing: '-0.025em', color: '#0D1829' }}>{money(total)}</span>
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, fontSize: 12, fontWeight: 700, color: '#1A7A42' }}>
-          <TrendUp weight="bold" size={12} />rinde
-        </span>
-      </div>
-      <div style={{ fontSize: 12, color: '#90A4B0', marginBottom: 16 }}>Capital invertido</div>
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
-        {instruments.map((inst) => (
-          <div key={inst.id} style={{ padding: '14px 15px', borderRadius: 12, background: SOFT_BG, border: '1px solid rgba(33,120,168,0.07)' }}>
-            <div style={{ ...LABEL_STYLE, fontSize: 9.5, marginBottom: 8 }}>{inst.type === 'plazo_fijo' ? 'Plazo fijo' : 'FCI'} · {inst.currency}</div>
-            <div style={{ fontSize: 12, color: '#4A6070', marginBottom: 8, lineHeight: 1.3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {inst.label?.trim() ? inst.label.trim() : inst.type === 'plazo_fijo' ? 'Plazo fijo' : 'FCI'}
-            </div>
-            <div style={{ fontSize: 18, fontWeight: 800, letterSpacing: '-0.03em', color: '#0D1829', marginBottom: 6 }}>{money(inst.amount, inst.currency)}</div>
-            <div style={{ fontSize: 11, color: '#90A4B0' }}>
-              {inst.type === 'plazo_fijo' && inst.due_date
-                ? `vence ${new Date(`${inst.due_date}T12:00:00-03:00`).toLocaleDateString('es-AR', { day: 'numeric', month: 'short' })}`
-                : 'disponible'}
-            </div>
-          </div>
-        ))}
-      </div>
-    </ModuleCard>
-  )
-}
-
-// ─── ÚLTIMOS MOVIMIENTOS (preview) ───────────────────────────
+// ─── ACTIVIDAD RECIENTE (preview) ────────────────────────────
 export function MovimientosModule({
   items,
   hidden,
@@ -429,427 +223,5 @@ export function MovimientosModule({
         </div>
       )}
     </ModuleCard>
-  )
-}
-
-// ════════════════ RIGHT RAIL ════════════════
-const QUICK: Array<{ id: string; label: string; icon: typeof MinusCircle; color: string; nav: NavId }> = [
-  { id: 'gasto', label: 'Registrar gasto', icon: MinusCircle, color: '#B84A12', nav: 'movimientos' },
-  { id: 'ingreso', label: 'Registrar ingreso', icon: PlusCircle, color: '#1A7A42', nav: 'movimientos' },
-  { id: 'meta', label: 'Aportar a meta', icon: Target, color: BLUE, nav: 'metas' },
-  { id: 'transfer', label: 'Transferencia', icon: ArrowsLeftRight, color: '#1B7E9E', nav: 'movimientos' },
-]
-
-export function RailAcciones({ onNav }: { onNav: (id: NavId) => void }) {
-  return (
-    <div style={{ ...CARD_STYLE, padding: '20px 22px' }}>
-      <div style={{ ...LABEL_STYLE, marginBottom: 16 }}>Acciones rápidas</div>
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
-        {QUICK.map((q) => {
-          const IconCmp = q.icon
-          return (
-            <button
-              key={q.id}
-              type="button"
-              onClick={() => onNav(q.nav)}
-              style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 9, padding: '14px', borderRadius: 13, background: SOFT_BG, border: '1px solid rgba(33,120,168,0.08)', cursor: 'pointer', fontFamily: 'inherit', textAlign: 'left' }}
-            >
-              <span style={{ width: 32, height: 32, borderRadius: 9, background: `${q.color}14`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <IconCmp weight="light" size={18} color={q.color} />
-              </span>
-              <span style={{ fontSize: 12.5, fontWeight: 600, color: '#0D1829', lineHeight: 1.25 }}>{q.label}</span>
-            </button>
-          )
-        })}
-      </div>
-    </div>
-  )
-}
-
-export function RailAlertas({ signals }: { signals: AttentionSignal[] }) {
-  if (signals.length === 0) {
-    return (
-      <div style={{ ...CARD_STYLE, padding: '20px 22px' }}>
-        <div style={{ ...LABEL_STYLE, marginBottom: 12 }}>Para revisar</div>
-        <p style={{ fontSize: 13, color: '#4A6070', lineHeight: 1.5, margin: 0 }}>Sin señales urgentes. La lectura del mes está estable.</p>
-      </div>
-    )
-  }
-  return (
-    <div style={{ ...CARD_STYLE, padding: '20px 22px' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
-        <span style={{ ...LABEL_STYLE, color: '#B84A12' }}>Para revisar</span>
-        <Warning weight="fill" size={13} color="#B84A12" />
-      </div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-        {signals.map((a) => (
-          <div key={a.id} style={{ display: 'flex', gap: 11 }}>
-            <span style={{ width: 7, height: 7, borderRadius: 9999, marginTop: 6, flexShrink: 0, background: a.tone === 'high' ? '#A61E1E' : a.tone === 'medium' ? '#B84A12' : BLUE }} />
-            <div>
-              <div style={{ fontSize: 13, fontWeight: 700, color: '#0D1829', lineHeight: 1.4 }}>{a.title}</div>
-              <div style={{ fontSize: 12, color: '#4A6070', marginTop: 3, lineHeight: 1.45 }}>{a.detail}</div>
-              <div style={{ fontSize: 11, color: '#90A4B0', marginTop: 4 }}>{a.dateLabel}</div>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
-
-// ─── ATENCIÓN AHORA (señales accionables, main module) ───────
-const ATTENTION_TONE: Record<AttentionSignal['tone'], { color: string; bg: string }> = {
-  high: { color: '#A61E1E', bg: 'rgba(166,30,30,0.09)' },
-  medium: { color: '#B84A12', bg: 'rgba(184,74,18,0.10)' },
-  low: { color: BLUE, bg: 'rgba(33,120,168,0.09)' },
-}
-
-function attentionIcon(id: string): typeof CreditCard {
-  if (id.startsWith('closing-') || id.startsWith('due-')) return CreditCard
-  if (id.startsWith('extra-')) return Receipt
-  return PencilSimple
-}
-
-export function AtencionAhoraModule({ signals }: { signals: AttentionSignal[] }) {
-  if (signals.length === 0) {
-    return (
-      <div style={{ ...CARD_STYLE, padding: '22px 24px', height: '100%' }}>
-        <div style={{ ...LABEL_STYLE, marginBottom: 14 }}>Atención ahora</div>
-        <p style={{ fontSize: 14, color: '#4A6070', lineHeight: 1.5, margin: 0 }}>
-          Sin señales urgentes. La lectura del mes está estable.
-        </p>
-      </div>
-    )
-  }
-  return (
-    <div style={{ ...CARD_STYLE, padding: '22px 24px', height: '100%' }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
-        <span style={LABEL_STYLE}>Atención ahora</span>
-        <span style={{ minWidth: 22, height: 22, padding: '0 7px', borderRadius: 9999, background: 'rgba(33,120,168,0.09)', color: BLUE, fontSize: 12, fontWeight: 700, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
-          {signals.length}
-        </span>
-      </div>
-      <div>
-        {signals.map((a, i) => {
-          const tone = ATTENTION_TONE[a.tone]
-          const IconCmp = attentionIcon(a.id)
-          return (
-            <div key={a.id} style={{ display: 'flex', alignItems: 'flex-start', gap: 13, padding: '15px 0', borderTop: i > 0 ? '1px solid rgba(33,120,168,0.07)' : 'none' }}>
-              <span style={{ width: 34, height: 34, borderRadius: 10, flexShrink: 0, marginTop: 1, background: tone.bg, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <IconCmp weight="light" size={18} color={tone.color} />
-              </span>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 10 }}>
-                  <span style={{ fontSize: 14, fontWeight: 700, color: '#0D1829', lineHeight: 1.35 }}>{a.title}</span>
-                  <span style={{ fontSize: 12, fontWeight: 600, color: tone.color, flexShrink: 0, whiteSpace: 'nowrap' }}>{a.dateLabel}</span>
-                </div>
-                <div style={{ fontSize: 12.5, color: '#4A6070', marginTop: 3, lineHeight: 1.45 }}>{a.detail}</div>
-              </div>
-            </div>
-          )
-        })}
-      </div>
-    </div>
-  )
-}
-
-// ─── PRÓXIMOS 30 DÍAS (agenda agrupada por mes) ──────────────
-const HORIZON_BADGE: Record<HorizonEvent['kind'], { label: string; color: string; bg: string; sign: '' | '+' | '−'; showAmount: boolean; amountColor: string }> = {
-  card: { label: 'Cierre', color: BLUE, bg: 'rgba(33,120,168,0.09)', sign: '', showAmount: false, amountColor: '#0D1829' },
-  due: { label: 'Vence', color: '#B84A12', bg: 'rgba(184,74,18,0.10)', sign: '', showAmount: true, amountColor: '#0D1829' },
-  instrument: { label: 'Libera', color: '#1A7A42', bg: 'rgba(26,122,66,0.10)', sign: '+', showAmount: true, amountColor: '#1A7A42' },
-  income: { label: 'Ingreso', color: '#1A7A42', bg: 'rgba(26,122,66,0.10)', sign: '+', showAmount: true, amountColor: '#1A7A42' },
-}
-
-function monthGroupLabel(dateStr: string): string {
-  const raw = new Date(`${dateStr}T12:00:00-03:00`).toLocaleDateString('es-AR', { month: 'long' })
-  return raw.toUpperCase()
-}
-
-export function Proximos30Module({
-  events,
-  money,
-  onNav,
-  limit = 6,
-}: {
-  events: HorizonEvent[]
-  money: Money
-  onNav: (id: NavId) => void
-  limit?: number
-}) {
-  const shown = events.slice(0, limit)
-  const groups: Array<{ label: string; items: HorizonEvent[] }> = []
-  for (const ev of shown) {
-    const label = monthGroupLabel(ev.date)
-    const last = groups[groups.length - 1]
-    if (last && last.label === label) last.items.push(ev)
-    else groups.push({ label, items: [ev] })
-  }
-  return (
-    <div style={{ ...CARD_STYLE, padding: '22px 24px', height: '100%' }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
-        <span style={LABEL_STYLE}>Próximos 30 días</span>
-        <button
-          type="button"
-          onClick={() => onNav('analisis')}
-          style={{ background: 'transparent', border: 0, cursor: 'pointer', padding: 0, display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 12, fontWeight: 600, color: BLUE, fontFamily: 'inherit' }}
-        >
-          Ver agenda <ArrowRight size={11} />
-        </button>
-      </div>
-      {shown.length === 0 ? (
-        <p style={{ fontSize: 14, color: '#4A6070', margin: '10px 0 0' }}>Sin eventos próximos por delante.</p>
-      ) : (
-        groups.map((group) => (
-          <div key={group.label}>
-            <div style={{ ...LABEL_STYLE, fontSize: 9.5, color: '#B8C9D4', margin: '16px 0 2px' }}>{group.label}</div>
-            {group.items.map((ev) => {
-              const badge = HORIZON_BADGE[ev.kind]
-              const d = new Date(`${ev.date}T12:00:00-03:00`)
-              return (
-                <div key={ev.id} style={{ display: 'grid', gridTemplateColumns: '40px 1fr auto', gap: 14, alignItems: 'center', padding: '13px 0', borderTop: '1px solid rgba(33,120,168,0.07)' }}>
-                  <div style={{ textAlign: 'left' }}>
-                    <div style={{ fontSize: 18, fontWeight: 800, letterSpacing: '-0.04em', color: '#0D1829', lineHeight: 1 }}>{d.getDate()}</div>
-                    <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.05em', textTransform: 'uppercase', color: '#90A4B0', marginTop: 2 }}>
-                      {d.toLocaleDateString('es-AR', { month: 'short' }).replace('.', '')}
-                    </div>
-                  </div>
-                  <div style={{ minWidth: 0 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                      <span style={{ fontSize: 14, fontWeight: 600, color: '#0D1829', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{ev.title}</span>
-                      <span style={{ padding: '2px 8px', borderRadius: 9999, fontSize: 10, fontWeight: 700, background: badge.bg, color: badge.color, flexShrink: 0 }}>{badge.label}</span>
-                    </div>
-                    <div style={{ fontSize: 11.5, color: '#90A4B0', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{ev.subtitle}</div>
-                  </div>
-                  {badge.showAmount && ev.amount !== undefined && ev.amount > 0 ? (
-                    <div style={{ textAlign: 'right', flexShrink: 0 }}>
-                      <div style={{ fontSize: 14, fontWeight: 800, color: badge.amountColor, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
-                        {badge.sign}{money(ev.amount, ev.currency ?? 'ARS')}
-                      </div>
-                      {ev.estimated && <div style={{ fontSize: 10, color: '#90A4B0', marginTop: 1 }}>estimado</div>}
-                    </div>
-                  ) : (
-                    <span />
-                  )}
-                </div>
-              )
-            })}
-          </div>
-        ))
-      )}
-    </div>
-  )
-}
-
-// ─── COMPROMISOS DEL MES (resumen de deuda por tarjeta) ──────
-export function CompromisosTotalesModule({
-  compromisos,
-  money,
-  onNav,
-}: {
-  compromisos: CompromisosData | null
-  money: Money
-  onNav: (id: NavId) => void
-}) {
-  const total = compromisos?.totalComprometido ?? 0
-  const porPagar = compromisos?.totalAPagar ?? 0
-  const enCurso = compromisos?.totalEnCurso ?? 0
-  const barTotal = Math.max(porPagar + enCurso, 1)
-
-  const rows = [
-    { key: 'pagar', label: 'Resúmenes por pagar', badge: 'por pagar', badgeColor: BLUE, badgeBg: 'rgba(33,120,168,0.09)', dot: BLUE, amount: porPagar },
-    { key: 'curso', label: 'Consumo del ciclo', badge: 'en curso', badgeColor: '#4A6070', badgeBg: 'rgba(74,96,112,0.10)', dot: '#1B7E9E', amount: enCurso },
-  ].filter((r) => r.amount > 0)
-
-  return (
-    <ModuleCard title="Compromisos del mes" action="Ver en Tarjetas" onAction={() => onNav('tarjetas')}>
-      {total <= 0 ? (
-        <p style={{ fontSize: 14, color: '#4A6070', margin: 0 }}>Sin compromisos de tarjeta este mes.</p>
-      ) : (
-        <>
-          <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, marginBottom: 12 }}>
-            <span style={{ fontSize: 30, fontWeight: 800, letterSpacing: '-0.035em', color: '#0D1829' }}>{money(total)}</span>
-            <span style={{ fontSize: 13, color: '#90A4B0' }}>comprometido este mes</span>
-          </div>
-          <div style={{ display: 'flex', height: 8, borderRadius: 4, overflow: 'hidden', gap: 2, marginBottom: 20, background: 'rgba(33,120,168,0.06)' }}>
-            {porPagar > 0 && <div style={{ flex: porPagar / barTotal, background: BLUE }} />}
-            {enCurso > 0 && <div style={{ flex: enCurso / barTotal, background: '#1B7E9E' }} />}
-          </div>
-          <div>
-            {rows.map((r, i) => (
-              <div key={r.key} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '13px 0', borderTop: i > 0 ? '1px solid rgba(33,120,168,0.07)' : 'none' }}>
-                <span style={{ width: 8, height: 8, borderRadius: 9999, flexShrink: 0, background: r.dot }} />
-                <span style={{ fontSize: 14, fontWeight: 600, color: '#0D1829' }}>{r.label}</span>
-                <span style={{ padding: '2px 8px', borderRadius: 9999, fontSize: 10, fontWeight: 700, background: r.badgeBg, color: r.badgeColor }}>{r.badge}</span>
-                <span style={{ flex: 1 }} />
-                <span style={{ fontSize: 15, fontWeight: 700, color: '#0D1829', fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>{money(r.amount)}</span>
-              </div>
-            ))}
-          </div>
-        </>
-      )}
-    </ModuleCard>
-  )
-}
-
-// ─── LO QUE VIENE (horizonte, main column) ───────────────────
-const HORIZON_META: Record<HorizonEvent['kind'], { section: NavId; color: string; bg: string; icon: typeof CreditCard; sign: string }> = {
-  card: { section: 'tarjetas', color: '#A61E1E', bg: 'rgba(166,30,30,0.09)', icon: CreditCard, sign: '−' },
-  due: { section: 'tarjetas', color: '#A61E1E', bg: 'rgba(166,30,30,0.09)', icon: CreditCard, sign: '−' },
-  income: { section: 'movimientos', color: '#1A7A42', bg: 'rgba(26,122,66,0.10)', icon: ArrowDownLeft, sign: '+' },
-  instrument: { section: 'instrumentos', color: '#1A7A42', bg: 'rgba(26,122,66,0.10)', icon: LockSimple, sign: '+' },
-}
-
-function relLabel(dateStr: string, today: Date): string {
-  const d = new Date(`${dateStr}T12:00:00-03:00`)
-  const days = Math.round((d.getTime() - today.getTime()) / 86_400_000)
-  if (days <= 0) return 'hoy'
-  if (days === 1) return 'mañana'
-  if (days <= 30) return `en ${days} días`
-  return `en ${Math.round(days / 7)} sem`
-}
-
-export function LoQueVieneModule({
-  events,
-  money,
-  onNav,
-}: {
-  events: HorizonEvent[]
-  money: Money
-  onNav: (id: NavId) => void
-}) {
-  const today = new Date()
-  const top = events.slice(0, 6)
-  if (top.length === 0) {
-    return (
-      <div style={{ ...CARD_STYLE, padding: '22px 24px' }}>
-        <div style={{ ...LABEL_STYLE, marginBottom: 12 }}>Próximos eventos</div>
-        <p style={{ fontSize: 14, color: '#4A6070', margin: 0 }}>Sin eventos próximos en los próximos 90 días.</p>
-      </div>
-    )
-  }
-  return (
-    <div style={{ ...CARD_STYLE, padding: '22px 24px' }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 18 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-          <span style={LABEL_STYLE}>Próximos eventos</span>
-          <span style={{ padding: '3px 9px', borderRadius: 9999, fontSize: 11, fontWeight: 700, background: 'rgba(33,120,168,0.09)', color: BLUE }}>{events.length} en 90 días</span>
-        </div>
-        <span style={{ fontSize: 12, color: '#90A4B0' }}>Tocá cada uno para ver el detalle</span>
-      </div>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12 }}>
-        {top.map((ev) => {
-          const meta = HORIZON_META[ev.kind]
-          const IconCmp = meta.icon
-          const d = new Date(`${ev.date}T12:00:00-03:00`)
-          return (
-            <button
-              key={ev.id}
-              type="button"
-              onClick={() => onNav(meta.section)}
-              style={{ textAlign: 'left', cursor: 'pointer', fontFamily: 'inherit', background: SOFT_BG, border: '1px solid rgba(33,120,168,0.08)', borderRadius: 14, padding: '14px 15px', display: 'flex', flexDirection: 'column', gap: 11 }}
-            >
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                <span style={{ width: 32, height: 32, borderRadius: 9, background: meta.bg, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                  <IconCmp weight="light" size={17} color={meta.color} />
-                </span>
-                <span style={{ fontSize: 11, fontWeight: 700, color: '#90A4B0' }}>{relLabel(ev.date, today)}</span>
-              </div>
-              <div style={{ minWidth: 0 }}>
-                <div style={{ fontSize: 13.5, fontWeight: 700, color: '#0D1829', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{ev.title}</div>
-                <div style={{ fontSize: 11.5, color: '#90A4B0', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{ev.subtitle}</div>
-              </div>
-              <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 6 }}>
-                <span style={{ fontSize: 11, fontWeight: 600, color: '#90A4B0' }}>
-                  {d.toLocaleDateString('es-AR', { day: 'numeric', month: 'short' })}{ev.estimated ? ' · est.' : ''}
-                </span>
-                {ev.amount !== undefined && ev.amount > 0 && (
-                  <span style={{ fontSize: 14, fontWeight: 800, color: meta.color, fontVariantNumeric: 'tabular-nums' }}>
-                    {meta.sign}{money(ev.amount, ev.currency ?? 'ARS')}
-                  </span>
-                )}
-              </div>
-            </button>
-          )
-        })}
-      </div>
-    </div>
-  )
-}
-
-// ─── INSIGHTS BREVES (→ Análisis) ────────────────────────────
-export function InsightsModule({
-  gastoTrendPct,
-  resultadoMes,
-  tasaAhorroPct,
-  money,
-  onNav,
-}: {
-  gastoTrendPct: number | null
-  resultadoMes: number
-  tasaAhorroPct: number | null
-  money: Money
-  onNav: (id: NavId) => void
-}) {
-  const insights: Array<{ key: string; icon: typeof TrendDown; color: string; bg: string; label: string; value: string; note: string }> = []
-
-  if (gastoTrendPct !== null) {
-    const down = gastoTrendPct <= 0
-    insights.push({
-      key: 'gasto',
-      icon: down ? TrendDown : TrendUp,
-      color: down ? '#1A7A42' : '#B84A12',
-      bg: down ? 'rgba(26,122,66,0.10)' : 'rgba(184,74,18,0.10)',
-      label: 'Gasto del mes',
-      value: `${down ? '↓' : '↑'} ${Math.abs(Math.round(gastoTrendPct))}%`,
-      note: down ? 'vs mes anterior, vas mejor' : 'vs mes anterior',
-    })
-  }
-
-  insights.push({
-    key: 'resultado',
-    icon: resultadoMes >= 0 ? TrendUp : TrendDown,
-    color: resultadoMes >= 0 ? '#1A7A42' : '#A61E1E',
-    bg: resultadoMes >= 0 ? 'rgba(26,122,66,0.10)' : 'rgba(166,30,30,0.09)',
-    label: 'Resultado del mes',
-    value: money(resultadoMes),
-    note: resultadoMes >= 0 ? 'ingresos menos gastos' : 'gastás más de lo que entra',
-  })
-
-  if (tasaAhorroPct !== null) {
-    insights.push({
-      key: 'ahorro',
-      icon: ArrowUpRight,
-      color: BLUE,
-      bg: 'rgba(33,120,168,0.09)',
-      label: 'Tasa de ahorro',
-      value: `${Math.round(tasaAhorroPct)}%`,
-      note: 'sobre tus ingresos',
-    })
-  }
-
-  return (
-    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 16 }}>
-      {insights.map((s) => {
-        const IconCmp = s.icon
-        return (
-          <button
-            key={s.key}
-            type="button"
-            onClick={() => onNav('analisis')}
-            style={{ ...CARD_STYLE, padding: '20px 22px', display: 'flex', alignItems: 'center', gap: 15, cursor: 'pointer', textAlign: 'left', fontFamily: 'inherit' }}
-          >
-            <span style={{ width: 42, height: 42, borderRadius: 12, flexShrink: 0, background: s.bg, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <IconCmp weight="light" size={21} color={s.color} />
-            </span>
-            <div style={{ minWidth: 0 }}>
-              <div style={{ ...LABEL_STYLE, fontSize: 10, marginBottom: 4 }}>{s.label}</div>
-              <div style={{ fontSize: 20, fontWeight: 700, letterSpacing: '-0.02em', color: '#0D1829' }}>{s.value}</div>
-              <div style={{ fontSize: 12, color: '#90A4B0', marginTop: 1 }}>{s.note}</div>
-            </div>
-          </button>
-        )
-      })}
-    </div>
   )
 }

--- a/components/dashboard/desktop/desktop-ui.tsx
+++ b/components/dashboard/desktop/desktop-ui.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { CSSProperties } from 'react'
-import { ArrowRight, Plus } from '@phosphor-icons/react'
+import { Plus } from '@phosphor-icons/react'
 import { formatAmount } from '@/lib/format'
 import { CategoryIcon, getCategoryColors } from '@/components/ui/CategoryIcon'
 
@@ -9,7 +9,6 @@ import { CategoryIcon, getCategoryColors } from '@/components/ui/CategoryIcon'
 export const BLUE = '#2178A8'
 
 // ─── Layout constants (control room) ─────────────────────────
-export const SIDEBAR_W = 248
 export const MAXW = 1520
 
 export const CARD_STYLE: CSSProperties = {
@@ -72,60 +71,6 @@ export function CatSquare({
   )
 }
 
-// ─── Panel card (Ciclo / Flujo / Metas / Instrumentos) ───────
-export function Panel({
-  title,
-  tag,
-  tagTone = 'primary',
-  children,
-}: {
-  title: string
-  tag?: string
-  tagTone?: 'primary' | 'muted' | 'warn'
-  children: React.ReactNode
-}) {
-  const tagColor = tagTone === 'warn' ? '#B84A12' : tagTone === 'muted' ? '#90A4B0' : BLUE
-  const tagBg =
-    tagTone === 'warn'
-      ? 'rgba(184,74,18,0.09)'
-      : tagTone === 'muted'
-        ? 'rgba(144,164,176,0.10)'
-        : 'rgba(33,120,168,0.09)'
-  return (
-    <div style={{ ...CARD_STYLE, padding: '26px 28px' }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 22 }}>
-        <div style={LABEL_STYLE}>{title}</div>
-        {tag && (
-          <span style={{ padding: '3px 9px', borderRadius: 9999, fontSize: 11, fontWeight: 600, background: tagBg, color: tagColor }}>
-            {tag}
-          </span>
-        )}
-      </div>
-      {children}
-    </div>
-  )
-}
-
-// ─── Blue sub-header band (non-panel views) ──────────────────
-export function BlueSubHeader({ title, meta }: { title: string; meta?: string }) {
-  return (
-    <div
-      style={{
-        background: 'linear-gradient(180deg, #2178A8 0%, #155E88 100%)',
-        borderBottomLeftRadius: 32,
-        borderBottomRightRadius: 32,
-        padding: '32px 0 36px',
-        marginBottom: 40,
-      }}
-    >
-      <div style={{ maxWidth: 1280, margin: '0 auto', padding: '0 48px' }}>
-        <div style={{ ...LABEL_STYLE, color: 'rgba(255,255,255,0.60)', marginBottom: 10 }}>{title}</div>
-        {meta && <div style={{ fontSize: 13, color: 'rgba(255,255,255,0.65)' }}>{meta}</div>}
-      </div>
-    </div>
-  )
-}
-
 // ─── Semantic badge ──────────────────────────────────────────
 export function Badge({ tone = 'success', children }: { tone?: 'success' | 'warning' | 'danger' | 'primary' | 'neutral'; children: React.ReactNode }) {
   const tones: Record<string, { bg: string; fg: string }> = {
@@ -140,64 +85,6 @@ export function Badge({ tone = 'success', children }: { tone?: 'success' | 'warn
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '3px 10px', borderRadius: 9999, background: t.bg, color: t.fg, fontSize: 11, fontWeight: 600 }}>
       {children}
     </span>
-  )
-}
-
-// ─── Section title (within Panel control room) ───────────────
-export function SectionTitle({
-  children,
-  sub,
-  action,
-  onAction,
-  accent = true,
-}: {
-  children: React.ReactNode
-  sub?: string
-  action?: string
-  onAction?: () => void
-  accent?: boolean
-}) {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'flex-end',
-        justifyContent: 'space-between',
-        marginBottom: 20,
-        paddingTop: 14,
-        borderTop: accent ? '1.5px solid #0D1829' : 'none',
-        position: 'relative',
-      }}
-    >
-      {accent && <span style={{ position: 'absolute', left: 0, top: -1.5, width: 46, height: 2, background: BLUE }} />}
-      <div style={{ display: 'flex', alignItems: 'baseline', gap: 10 }}>
-        <h2 style={{ margin: 0, fontSize: 20, fontWeight: 700, letterSpacing: '-0.025em', color: '#0D1829' }}>{children}</h2>
-        {sub && <span style={{ fontSize: 13, color: '#90A4B0' }}>{sub}</span>}
-      </div>
-      {action && onAction && (
-        <button
-          type="button"
-          onClick={onAction}
-          style={{
-            background: 'transparent',
-            border: 0,
-            cursor: 'pointer',
-            padding: 0,
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 5,
-            fontSize: 12,
-            fontWeight: 600,
-            color: BLUE,
-            fontFamily: 'inherit',
-            borderBottom: '1px solid rgba(33,120,168,0.25)',
-            paddingBottom: 1,
-          }}
-        >
-          {action} <ArrowRight size={12} />
-        </button>
-      )}
-    </div>
   )
 }
 


### PR DESCRIPTION
Rediseño del Home /web como sala de control calma del presente:

- Topnav sobrio (wordmark + navegación + mes + USD oficial + ojo + avatar)
  que reemplaza el sidebar; se quitan SmartInput y campana sin funcionalidad.
- Hero editorial: Saldo Vivo dominante sobre fondo, barra de propiedad que
  parte el total en Disponible Real (azul) y Ya tiene destino (rayado), con
  microcopy que explica la brecha (consumos de tarjeta sin pagar).
- Atención ahora junto al hero, con montos reales por señal (cierre con
  consumo del ciclo, vencimiento con monto a pagar) y estado calmo honesto.
- Próximos 30 días como riel de consecuencias (qué mueve la caja y por qué),
  curado a 5 eventos dentro de 30 días.
- Módulo Ya tiene destino con desglose que suma exactamente la brecha del
  hero (resúmenes por pagar / ciclo en curso / otros) y suscripciones por
  facturar separadas como no incluidas.
- Secundarios reducidos: Liquidez, Presupuesto, Actividad reciente y Ritmo
  del mes (observado a hoy, sin compromisos futuros). Se degradan del Panel
  Tarjetas, Metas, Insights y el sparkline decorativo (siguen por navegación).
- Fallback de gasto percibido ahora excluye crédito y pagos de tarjeta.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Br9GVjYq1XhMQ6oEs19gDE