### PR TITLE
feat(intelligence): snapshot con extraordinarios, metas, recurrentes y cuotas futuras

### DIFF
--- a/components/assistant/GotaAssistant.tsx
+++ b/components/assistant/GotaAssistant.tsx
@@ -15,8 +15,9 @@ type ChatMessage = AssistantHistoryMessage & {
 }
 
 const SUGGESTIONS = [
-  'En que estoy gastando mas este mes?',
-  'Cuanto me queda disponible?',
+  'Cuanto puedo gastar por dia hasta fin de mes?',
+  'Como vienen mis cuotas de los proximos meses?',
+  'Cuanto llevo en deseos este mes?',
   'Que deberia mirar hoy?',
 ]
 

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -22,8 +22,9 @@ import { PendingSharedReceiptBanner } from '@/components/share-target/PendingSha
 import { SharedReceiptPreviewModal } from '@/components/share-target/SharedReceiptPreviewModal'
 import { useAnonymousBannerTone } from '@/components/anonymous-banner/AnonymousBannerToneProvider'
 import { BlueHeaderZone } from '@/components/ui/BlueHeaderZone'
+import { IntelligenceHero } from '@/components/intelligence/IntelligenceHero'
 import { useCardPaymentPrompts } from '@/hooks/useCardPaymentPrompts'
-import { FF_INSTRUMENTS } from '@/lib/flags'
+import { FF_INSTRUMENTS, FF_INTELLIGENCE } from '@/lib/flags'
 import { trackEvent } from '@/lib/product-analytics/client'
 import { getHomeEmptyState } from '@/lib/home-empty-state'
 import { readPendingSharedReceipt, type PendingSharedReceipt } from '@/lib/share-target'
@@ -474,6 +475,11 @@ export function DashboardShell({
                 selectedMonth={selectedMonth}
                 amountsVisible={amountsVisible}
               />
+            )}
+
+            {/* Lectura inteligente del mes: ritmo diario + señales con evidencia */}
+            {FF_INTELLIGENCE && isCurrentMonth && hasAnyMovement && (
+              <IntelligenceHero surface="home-mobile" />
             )}
 
             {homeEmptyState.showPrimaryActivation && (

--- a/components/intelligence/IntelligenceHero.tsx
+++ b/components/intelligence/IntelligenceHero.tsx
@@ -7,19 +7,26 @@ import {
   ArrowClockwise,
   ChartLineUp,
   ChatCircleDots,
+  Coins,
   CreditCard,
   Gauge,
+  HandCoins,
+  Heart,
   Lightning,
+  Receipt,
   Sparkle,
+  Target,
   Wallet,
 } from '@phosphor-icons/react'
 import { requestAssistantOpen } from '@/lib/assistant/events'
 import { FF_GOTA_ASSISTANT } from '@/lib/flags'
+import { formatAmount } from '@/lib/format'
 import type {
   IntelligenceHero as IntelligenceHeroData,
   IntelligenceHeroResponse,
+  IntelligencePulse,
 } from '@/lib/intelligence/heroes'
-import type { InsightSeverity } from '@/lib/intelligence/types'
+import type { Currency, InsightSeverity } from '@/lib/intelligence/types'
 
 /** Datos de héroes inteligentes compartidos entre superficies (cache 5 min). */
 export function useIntelligenceHeroes(enabled = true) {
@@ -53,6 +60,11 @@ const KIND_ICONS: Record<string, Icon> = {
   same_day_spend_delta: ChartLineUp,
   liquidity_watch: Wallet,
   recent_unusual_movement: Lightning,
+  installment_load: Coins,
+  wants_creep: Heart,
+  goal_pace: Target,
+  income_missing: HandCoins,
+  subscription_load: Receipt,
 }
 
 function HeroCta({ hero }: { hero: IntelligenceHeroData }) {
@@ -164,6 +176,41 @@ export function IntelligenceSignalChip({ hero }: { hero: IntelligenceHeroData })
   return <div className={className}>{content}</div>
 }
 
+/** Ritmo del mes: cuánto queda por día sin tocar compromisos ni metas. */
+function PulseRow({ pulse, currency }: { pulse: IntelligencePulse; currency: Currency }) {
+  const over = pulse.spendable <= 0 || pulse.dailyAmount === null
+  return (
+    <div className="card-s5 flex items-center gap-3 p-3.5">
+      <span
+        className="grid h-8 w-8 shrink-0 place-items-center rounded-full"
+        style={{
+          background: over ? 'var(--color-warning-soft)' : 'var(--color-primary-soft)',
+          color: over ? 'var(--color-warning)' : 'var(--color-primary)',
+        }}
+      >
+        <Gauge size={17} weight="duotone" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="type-meta text-text-dim">Ritmo del mes</p>
+        {over ? (
+          <p className="text-[13px] font-bold text-text-primary">
+            Sin margen libre: lo que queda ya está comprometido
+          </p>
+        ) : (
+          <p className="text-[13px] font-bold tabular-nums text-text-primary">
+            {formatAmount(pulse.dailyAmount ?? 0, currency)}/día por {pulse.daysLeft} días
+          </p>
+        )}
+      </div>
+      {!over && (
+        <span className="whitespace-nowrap type-meta text-text-secondary">
+          {formatAmount(pulse.spendable, currency)} libres
+        </span>
+      )}
+    </div>
+  )
+}
+
 function EmptyCard() {
   return (
     <article className="card-s5 flex items-center gap-3 p-4">
@@ -203,13 +250,21 @@ export function IntelligenceSignalChips({ heroes }: { heroes: IntelligenceHeroDa
 }
 
 /**
- * Card completa con hero primario + chips. No se usa en Análisis (ahí la señal
- * se integra al hero azul); queda como superficie standalone para Home mobile.
+ * Card completa con hero primario + pulso del mes + chips.
+ * - `standalone`: con wrapper propio (padding), estado vacío visible.
+ * - `home-mobile`: sin wrapper (la white zone del Home ya maneja padding y gap)
+ *   y silenciosa cuando no hay nada para decir (cero ruido en el Home).
  */
-export function IntelligenceHero() {
+export function IntelligenceHero({
+  surface = 'standalone',
+}: {
+  surface?: 'standalone' | 'home-mobile'
+}) {
   const { data, isLoading, isError, refetch } = useIntelligenceHeroes()
+  const isHome = surface === 'home-mobile'
 
   if (isLoading) {
+    if (isHome) return <div className="skeleton h-16 rounded-[18px]" />
     return (
       <section className="px-5 pt-4">
         <div className="skeleton h-36 rounded-card" />
@@ -218,6 +273,8 @@ export function IntelligenceHero() {
   }
 
   if (isError || !data) {
+    // En el Home el error se degrada en silencio: no es una superficie crítica.
+    if (isHome) return null
     return (
       <section className="px-5 pt-4">
         <button
@@ -233,14 +290,22 @@ export function IntelligenceHero() {
   }
 
   const [primary, ...secondary] = data.heroes
+  const pulse = data.pulse ?? null
 
-  return (
-    <section className="px-5 pt-4">
+  const content = (
+    <>
+      {pulse && <PulseRow pulse={pulse} currency={data.currency} />}
       {primary ? (
         <>
           <PrimaryHeroCard hero={primary} />
           {secondary.length > 0 && (
-            <div className="scrollbar-none -mx-5 mt-3 flex gap-2 overflow-x-auto px-5">
+            <div
+              className={
+                isHome
+                  ? 'scrollbar-none flex gap-2 overflow-x-auto'
+                  : 'scrollbar-none -mx-5 flex gap-2 overflow-x-auto px-5'
+              }
+            >
               {secondary.map((hero) => (
                 <IntelligenceSignalChip key={hero.id} hero={hero} />
               ))}
@@ -248,8 +313,15 @@ export function IntelligenceHero() {
           )}
         </>
       ) : (
-        <EmptyCard />
+        !isHome && <EmptyCard />
       )}
-    </section>
+    </>
   )
+
+  if (isHome) {
+    if (!pulse && !primary) return null
+    return <div className="flex flex-col gap-3">{content}</div>
+  }
+
+  return <section className="flex flex-col gap-3 px-5 pt-4">{content}</section>
 }

--- a/docs/gota-intelligence-overview.md
+++ b/docs/gota-intelligence-overview.md
@@ -85,7 +85,7 @@ Claves del diseño:
 | Regla | Dispara cuando | Severidad |
 |---|---|---|
 | `upcoming_card_due` | Resumen cerrado/vencido con monto pendiente y vencimiento ≤ 7 días | risk / watch |
-| `liquidity_watch` | Disponible Real < compromisos fechados de los próximos 14 días (resúmenes + suscripciones débito) | risk |
+| `liquidity_watch` | Saldo Vivo (caja) < compromisos fechados de los próximos 14 días (resúmenes + suscripciones débito). v2: antes usaba Disponible Real, que ya netea los resúmenes (doble descuento) | risk |
 | `budget_acceleration` | Categoría con uso ≥ avance del mes + 20 puntos (y ≥ 25% del presupuesto consumido) | risk / watch |
 | `same_day_spend_delta` | Gasto observado a hoy ≥ ±15% vs promedio histórico al mismo día (risk si ≥ +35%) | risk / watch / positive |
 | `recent_unusual_movement` | Gasto reciente ≥ 3× el ticket habitual de su categoría (con ≥ 5 compras de historial) | watch / info |

--- a/docs/gota-intelligence-overview.md
+++ b/docs/gota-intelligence-overview.md
@@ -17,7 +17,7 @@ La v2 mantiene el principio *deterministic before generative* y extiende motor +
 - `futureInstallments`: cuotas ya materializadas de los próximos 6 meses (los installments se guardan como gastos con fecha futura → esto suma compromisos reales, no estima).
 
 **Motor de proyección** (`lib/intelligence/projection.ts`):
-- `computeSafeToSpend`: libre hasta fin de mes = disponible − compromisos fechados del mes − metas; ritmo diario sugerido.
+- `computeSafeToSpend`: libre hasta fin de mes = Disponible Real − débitos automáticos restantes del mes − metas; ritmo diario sugerido. (Disponible Real ya descuenta toda la deuda de tarjeta — resúmenes y ciclo en curso — así que el pulso no la vuelve a restar.)
 - `computeInstallmentHorizon`: carga de cuotas por mes futuro vs ingreso de referencia (recurrentes o promedio histórico).
 - `simulatePurchase`: "¿me alcanza X?" al contado (margen restante) o en N cuotas (carga futura por mes). El LLM solo redacta el veredicto ya calculado.
 
@@ -30,7 +30,7 @@ La v2 mantiene el principio *deterministic before generative* y extiende motor +
 - `/api/intelligence/heroes` devuelve `pulse` además de `heroes`.
 - Sugerencias del chat renovadas hacia las capacidades nuevas.
 
-Tests: 141 en `lib/intelligence` (84 → 141). `npm run test`, lint y build verificados.
+Tests: 142 en `lib/intelligence` (84 → 142). `npm run test`, lint y build verificados.
 
 ---
 

--- a/docs/gota-intelligence-overview.md
+++ b/docs/gota-intelligence-overview.md
@@ -2,6 +2,35 @@
 
 > **Branch:** `feat/intelligence-layer` · **Fecha:** 2026-07-07 · **Estado:** implementado, verificado, sin pushear
 > Plan técnico detallado: [`docs/plans/2026-07-07-gota-intelligence-architecture.md`](plans/2026-07-07-gota-intelligence-architecture.md)
+> **v2 (2026-07-09):** ver sección 0 — proyección, datos nuevos y superficie en Home.
+
+---
+
+## 0. v2 — Qué se agregó (2026-07-09)
+
+La v2 mantiene el principio *deterministic before generative* y extiende motor + superficies:
+
+**Datos nuevos en el snapshot** (`lib/intelligence/snapshot.ts`):
+- `is_extraordinary` en movimientos y agregados, con fallback de query si la columna no existe. Los baselines (same-day, ticket habitual) ahora **excluyen extraordinarios** — corrige señales que antes comparaban contra histórico contaminado.
+- `goalsDetail`: métricas completas por meta (pace, aporte requerido, fecha objetivo) que el snapshot v1 descartaba.
+- `recurringIncomes` con estado pendiente del mes.
+- `futureInstallments`: cuotas ya materializadas de los próximos 6 meses (los installments se guardan como gastos con fecha futura → esto suma compromisos reales, no estima).
+
+**Motor de proyección** (`lib/intelligence/projection.ts`):
+- `computeSafeToSpend`: libre hasta fin de mes = disponible − compromisos fechados del mes − metas; ritmo diario sugerido.
+- `computeInstallmentHorizon`: carga de cuotas por mes futuro vs ingreso de referencia (recurrentes o promedio histórico).
+- `simulatePurchase`: "¿me alcanza X?" al contado (margen restante) o en N cuotas (carga futura por mes). El LLM solo redacta el veredicto ya calculado.
+
+**5 reglas nuevas** (total 10): `installment_load` (mes futuro con ≥25%/40% del ingreso en cuotas), `wants_creep` (share de deseos despegado del promedio, con lado positivo), `goal_pace` (meta atrasada con aporte necesario / encaminada), `income_missing` (recurrente que no llegó, gracia 2 días), `subscription_load` (≥12%/20% del ingreso).
+
+**Chat** (3 intents nuevos, total 14): `affordability` (extrae monto — soporta "250.000", "250 lucas", "50k", "1 palo" — y cuotas; responde con veredicto determinístico), `wants_question` (share + movimientos deseo), `installment_question` (horizonte de cuotas). Además: metas por meta en `goal_question`, safe-to-spend en `balance_status`.
+
+**UX — la inteligencia ahora se ve**:
+- `IntelligenceHero` se monta en el **Home mobile** (`DashboardShell`, mes corriente con movimientos): pulso "Ritmo del mes" ($X/día libres tras compromisos y metas) + señal primaria + chips. Silencioso si no hay nada para decir.
+- `/api/intelligence/heroes` devuelve `pulse` además de `heroes`.
+- Sugerencias del chat renovadas hacia las capacidades nuevas.
+
+Tests: 141 en `lib/intelligence` (84 → 141). `npm run test`, lint y build verificados.
 
 ---
 

--- a/lib/intelligence/__tests__/chat-evidence.test.ts
+++ b/lib/intelligence/__tests__/chat-evidence.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { buildAnswerPacket } from '../chat-evidence'
 import { planChatQuery } from '../chat-planner'
 import {
+  futureInstallmentExpenses,
   makeBudgetSnapshot,
   makeCard,
   makeExpense,
   HISTORY_MONTHS,
   makeFreshUserSnapshot,
+  makeGoal,
   makeInputs,
   makeSnapshot,
 } from './fixtures'
@@ -305,5 +307,101 @@ describe('followUps', () => {
   it('cada intent trae follow-ups determinísticos', () => {
     const packet = packetFor('¿Cuánto me queda realmente disponible?')
     expect(packet.followUps.length).toBeGreaterThan(0)
+  })
+})
+
+describe('affordability — "¿me alcanza?"', () => {
+  it('con monto que entra: veredicto positivo precalculado', () => {
+    const packet = packetFor('¿Me alcanza para comprar algo de 250.000?')
+    expect(packet.intent).toBe('affordability')
+    const verdict = packet.facts.find((fact) => fact.label === 'Veredicto')
+    expect(verdict?.value).toContain('entra')
+    expect(verdict?.value).not.toContain('no entra')
+    expect(labels(packet)).toContain('Libre hasta fin de mes')
+  })
+
+  it('con monto que no entra: veredicto negativo', () => {
+    const packet = packetFor('¿Me alcanza para comprar algo de 700.000?')
+    expect(packet.facts.find((fact) => fact.label === 'Veredicto')?.value).toContain('no entra')
+  })
+
+  it('en cuotas: cuota resultante y carga futura por mes', () => {
+    const packet = packetFor(
+      '¿Me alcanza comprar algo de 600.000 en 6 cuotas?',
+      makeSnapshot({
+        futureExpenses: futureInstallmentExpenses([{ month: '2026-08', amount: 200_000 }]),
+      }),
+    )
+    const simulation = packet.facts.find((fact) => fact.label.startsWith('Simulación'))
+    expect(simulation?.value).toContain('100.000')
+    expect(labels(packet).some((label) => label.startsWith('Cuotas ago 2026 con esta compra'))).toBe(
+      true,
+    )
+  })
+
+  it('sin monto: responde con el margen general y lo avisa', () => {
+    const packet = packetFor('¿Cuánto puedo gastar por día hasta fin de mes?')
+    expect(labels(packet)).toContain('Ritmo sugerido')
+    expect(packet.caveats.some((caveat) => caveat.includes('No detecté un monto'))).toBe(true)
+  })
+})
+
+describe('wants_question — "¿cuánto llevo en deseos?"', () => {
+  it('incluye share actual, histórico y solo movimientos deseo', () => {
+    const packet = packetFor('¿Cuánto llevo en deseos este mes?')
+    expect(packet.intent).toBe('wants_question')
+    expect(labels(packet)).toContain('Deseos este mes a la fecha')
+    expect(labels(packet)).toContain('Peso habitual de deseos')
+    expect(packet.movements.length).toBeGreaterThan(0)
+    expect(packet.movements.every((movement) => movement.description === 'Pedido delivery')).toBe(
+      true,
+    )
+  })
+})
+
+describe('installment_question — "¿cómo vienen mis cuotas?"', () => {
+  it('lista la carga por mes futuro con peso sobre el ingreso', () => {
+    const packet = packetFor(
+      '¿Cómo vienen mis cuotas de los próximos meses?',
+      makeSnapshot({
+        futureExpenses: futureInstallmentExpenses([
+          { month: '2026-08', amount: 200_000 },
+          { month: '2026-09', amount: 300_000 },
+        ]),
+      }),
+    )
+    expect(labels(packet)).toContain('Cuotas ago 2026')
+    expect(labels(packet)).toContain('Cuotas sep 2026')
+    expect(
+      packet.facts.find((fact) => fact.label === 'Cuotas sep 2026')?.value,
+    ).toContain('30% del ingreso')
+  })
+
+  it('sin cuotas futuras lo dice con caveat', () => {
+    const packet = packetFor('¿Cómo vienen mis cuotas de los próximos meses?')
+    expect(packet.caveats.some((caveat) => caveat.includes('cuotas'))).toBe(true)
+  })
+})
+
+describe('goal_question con detalle por meta', () => {
+  it('cada meta trae avance, estado y aporte necesario', () => {
+    const packet = packetFor(
+      '¿Cómo vienen mis metas?',
+      makeSnapshot({
+        goalsDetail: [makeGoal()],
+        goals: { count: 1, committed: { ARS: 300_000, USD: 0 } },
+      }),
+    )
+    const goalFact = packet.facts.find((fact) => fact.label === 'Meta Viaje')
+    expect(goalFact?.value).toContain('25%')
+    expect(goalFact?.value).toContain('atrasada')
+    expect(goalFact?.value).toContain('180.000')
+  })
+})
+
+describe('safe-to-spend en balance_status', () => {
+  it('incluye el ritmo sugerido hasta fin de mes', () => {
+    const packet = packetFor('¿Cuánto me queda realmente disponible?')
+    expect(labels(packet)).toContain('Ritmo sugerido hasta fin de mes')
   })
 })

--- a/lib/intelligence/__tests__/chat-planner.test.ts
+++ b/lib/intelligence/__tests__/chat-planner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectIntent, extractSearchTerms, planChatQuery } from '../chat-planner'
+import { detectIntent, extractSearchTerms, extractSimulation, planChatQuery } from '../chat-planner'
 
 describe('detectIntent — preguntas de aceptación', () => {
   const cases: Array<[string, string]> = [
@@ -93,5 +93,68 @@ describe('extractSearchTerms', () => {
 
   it('descarta tokens cortos', () => {
     expect(extractSearchTerms('qué es eso')).toEqual([])
+  })
+})
+
+describe('intents v2 — affordability, deseos y cuotas', () => {
+  const cases: Array<[string, string]> = [
+    ['¿Me alcanza para comprar algo de 250.000?', 'affordability'],
+    ['¿Cuánto puedo gastar por día hasta fin de mes?', 'affordability'],
+    ['¿Puedo darme el gusto de una compra grande?', 'affordability'],
+    ['¿Cuánto llevo en deseos este mes?', 'wants_question'],
+    ['¿Cómo vienen mis cuotas de los próximos meses?', 'installment_question'],
+    ['¿Cuánto tengo financiado en la tarjeta?', 'installment_question'],
+    ['¿Qué resumen me vence esta semana?', 'card_commitments'],
+  ]
+
+  it.each(cases)('"%s" → %s', (question, intent) => {
+    expect(detectIntent(question)).toBe(intent)
+  })
+
+  it('"deseo saber..." no dispara wants_question', () => {
+    expect(detectIntent('Deseo saber cuánto gasté este mes')).not.toBe('wants_question')
+  })
+
+  it('wants_question filtra movimientos marcados como deseo del mes', () => {
+    const plan = planChatQuery('¿Cuánto llevo en deseos este mes?')
+    expect(plan.includeMovements).toBe(true)
+    expect(plan.movementFilter.wantsOnly).toBe(true)
+    expect(plan.movementFilter.kind).toBe('gasto')
+    expect(plan.movementFilter.window).toBe('this_month')
+  })
+})
+
+describe('extractSimulation', () => {
+  it('monto con separador de miles argentino', () => {
+    expect(extractSimulation('¿Me alcanza para algo de 250.000?')).toEqual({
+      amount: 250_000,
+      installments: null,
+    })
+  })
+
+  it('monto en lucas con cuotas', () => {
+    expect(extractSimulation('¿Puedo comprar algo de 250 lucas en 6 cuotas?')).toEqual({
+      amount: 250_000,
+      installments: 6,
+    })
+  })
+
+  it('sufijo k y palos', () => {
+    expect(extractSimulation('¿me alcanza si gasto 50k?').amount).toBe(50_000)
+    expect(extractSimulation('¿puedo gastar 1 palo?').amount).toBe(1_000_000)
+  })
+
+  it('el número de cuotas no se confunde con el monto', () => {
+    expect(extractSimulation('¿Me alcanza 12 cuotas de 30.000?')).toEqual({
+      amount: 30_000,
+      installments: 12,
+    })
+  })
+
+  it('sin monto explícito devuelve null', () => {
+    expect(extractSimulation('¿Me alcanza para una compra grande?')).toEqual({
+      amount: null,
+      installments: null,
+    })
   })
 })

--- a/lib/intelligence/__tests__/features.test.ts
+++ b/lib/intelligence/__tests__/features.test.ts
@@ -112,7 +112,7 @@ describe('computeUpcomingCardDues', () => {
 describe('computeLiquidity', () => {
   it('suma resúmenes próximos y suscripciones DEBIT de la moneda base', () => {
     const snapshot = makeSnapshot({
-      disponibleReal: { ARS: 200_000, USD: 0 },
+      saldoVivo: { ARS: 200_000, USD: 0 },
       cards: [
         makeCard({
           pendingStatements: [
@@ -129,6 +129,7 @@ describe('computeLiquidity', () => {
     const liquidity = computeLiquidity(snapshot, 14)
     expect(liquidity.upcomingTotal).toBe(325_000)
     expect(liquidity.items.map((item) => item.label)).toEqual(['Gimnasio', 'Resumen Visa Galicia'])
+    expect(liquidity.saldo).toBe(200_000)
     expect(liquidity.gap).toBe(-125_000)
   })
 })

--- a/lib/intelligence/__tests__/features.test.ts
+++ b/lib/intelligence/__tests__/features.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import {
   computeBudgetPace,
+  computeGoalPace,
   computeLiquidity,
+  computeMissingIncomes,
   computeSameDaySpend,
   computeUnusualMovements,
   computeUpcomingCardDues,
+  computeWantsShare,
   getMonthProgress,
 } from '../features'
 import {
@@ -13,8 +16,10 @@ import {
   makeExpense,
   makeBudgetSnapshot,
   makeFreshUserSnapshot,
+  makeGoal,
   makeIncome,
   makeInputs,
+  makeRecurringIncome,
   makeSnapshot,
   makeSubscription,
   monthPatternExpenses,
@@ -263,5 +268,140 @@ describe('ingresos del snapshot', () => {
     })
     expect(snapshot.monthIncome.ARS).toBe(1_000_000)
     expect(snapshot.monthIncome.USD).toBe(300)
+  })
+})
+
+describe('exclusión de gastos extraordinarios', () => {
+  it('un gasto extraordinario del mes no infla el same-day', () => {
+    const snapshot = makeSnapshot({
+      expenses: [
+        ...makeInputs().expenses,
+        makeExpense({
+          date: '2026-07-10',
+          amount: 100_000,
+          category: 'Salud y Farmacia',
+          description: 'Tratamiento dental',
+          is_extraordinary: true,
+        }),
+      ],
+    })
+    const feature = computeSameDaySpend(snapshot)
+    expect(feature.currentAmount).toBe(140_000)
+    expect(feature.deltaPct).toBe(0)
+    expect(feature.extraordinaryExcluded).toBe(100_000)
+  })
+
+  it('un extraordinario histórico no infla el baseline same-day', () => {
+    const snapshot = makeSnapshot({
+      expenses: [
+        ...makeInputs().expenses,
+        makeExpense({
+          date: '2026-06-10',
+          amount: 100_000,
+          category: 'Salud y Farmacia',
+          is_extraordinary: true,
+        }),
+      ],
+    })
+    const feature = computeSameDaySpend(snapshot)
+    expect(feature.baselineAmount).toBe(140_000)
+    expect(feature.deltaPct).toBe(0)
+  })
+
+  it('un extraordinario histórico no infla el ticket habitual de la categoría', () => {
+    const snapshot = makeSnapshot({
+      expenses: [
+        ...makeInputs().expenses,
+        makeExpense({ date: '2026-06-05', amount: 500_000, is_extraordinary: true }),
+        makeExpense({ date: '2026-07-14', amount: 130_000, description: 'Compra grande super' }),
+      ],
+    })
+    const [unusual] = computeUnusualMovements(snapshot)
+    expect(unusual).toBeDefined()
+    expect(unusual.movement.description).toBe('Compra grande super')
+    expect(unusual.baselineTicket).toBe(40_000)
+  })
+
+  it('un gasto ya marcado extraordinario no se reporta como fuera de patrón', () => {
+    const snapshot = makeSnapshot({
+      expenses: [
+        ...makeInputs().expenses,
+        makeExpense({ date: '2026-07-14', amount: 300_000, is_extraordinary: true }),
+      ],
+    })
+    expect(computeUnusualMovements(snapshot)).toEqual([])
+  })
+})
+
+describe('computeWantsShare', () => {
+  it('escenario estable: share actual igual al histórico', () => {
+    const feature = computeWantsShare(makeSnapshot())
+    expect(feature.currentSharePct).toBe(14)
+    expect(feature.baselineSharePct).toBe(9)
+    expect(feature.baselineMonths).toBe(5)
+    expect(feature.dataQuality).toBe('ok')
+  })
+
+  it('mes con deseos disparados: delta positivo grande', () => {
+    const feature = computeWantsShare(
+      makeSnapshot({
+        expenses: [
+          ...makeInputs().expenses,
+          makeExpense({
+            date: '2026-07-12',
+            amount: 100_000,
+            category: 'Ocio',
+            description: 'Escapada',
+            is_want: true,
+          }),
+        ],
+      }),
+    )
+    expect(feature.currentWants).toBe(120_000)
+    expect(feature.currentSharePct).toBe(50)
+    expect(feature.deltaPts).toBe(41)
+  })
+
+  it('sin meses previos con deseos clasificados no hay línea base', () => {
+    const noWantsHistory = makeInputs().expenses.map((expense) => ({
+      ...expense,
+      is_want: expense.date.startsWith(MONTH) ? expense.is_want : false,
+    }))
+    const feature = computeWantsShare(makeSnapshot({ expenses: noWantsHistory }))
+    expect(feature.dataQuality).toBe('insufficient')
+    expect(feature.baselineSharePct).toBeNull()
+  })
+})
+
+describe('computeGoalPace', () => {
+  it('separa metas atrasadas de encaminadas y ordena por fecha objetivo', () => {
+    const pace = computeGoalPace(
+      makeSnapshot({
+        goalsDetail: [
+          makeGoal({ id: 'g-later', targetDate: '2027-06-30' }),
+          makeGoal({ id: 'g-soon', targetDate: '2026-10-31' }),
+          makeGoal({ id: 'g-ok', paceStatus: 'on_track', progressPct: 60 }),
+          makeGoal({ id: 'g-paused', status: 'paused' }),
+        ],
+      }),
+    )
+    expect(pace.behind.map((goal) => goal.id)).toEqual(['g-soon', 'g-later'])
+    expect(pace.onTrack.map((goal) => goal.id)).toEqual(['g-ok'])
+  })
+})
+
+describe('computeMissingIncomes', () => {
+  it('reporta el recurrente pendiente pasado el período de gracia', () => {
+    const missing = computeMissingIncomes(
+      makeSnapshot({
+        recurringIncomes: [
+          makeRecurringIncome({ pendingThisMonth: true, dayOfMonth: 5 }),
+          makeRecurringIncome({ id: 'rec-2', pendingThisMonth: true, dayOfMonth: 14 }),
+          makeRecurringIncome({ id: 'rec-3', pendingThisMonth: false, dayOfMonth: 1 }),
+        ],
+      }),
+    )
+    // Hoy es 15: el del día 5 ya venció la gracia; el del 14 todavía no.
+    expect(missing.map((income) => income.id)).toEqual(['rec-1'])
   })
 })

--- a/lib/intelligence/__tests__/fixtures.ts
+++ b/lib/intelligence/__tests__/fixtures.ts
@@ -6,7 +6,13 @@ import {
   type SnapshotIncomeRow,
   type SnapshotInputs,
 } from '../snapshot'
-import type { FinancialSnapshot, SnapshotCardCommitment, SnapshotSubscription } from '../types'
+import type {
+  FinancialSnapshot,
+  SnapshotCardCommitment,
+  SnapshotGoal,
+  SnapshotRecurringIncome,
+  SnapshotSubscription,
+} from '../types'
 
 /**
  * Escenario base: usuario ARS con 5 meses completos de histórico estable.
@@ -196,4 +202,56 @@ export function makeFreshUserSnapshot(): FinancialSnapshot {
     incomeEntries: [makeIncome({ date: `${MONTH}-01`, amount: 1_000_000 })],
     earliestDataMonth: MONTH,
   })
+}
+
+// ─── Fixtures v2: metas, recurrentes y cuotas futuras ───────────────────────
+
+export function makeGoal(overrides?: Partial<SnapshotGoal>): SnapshotGoal {
+  return {
+    id: 'goal-1',
+    name: 'Viaje',
+    status: 'active',
+    currency: 'ARS',
+    targetAmount: 1_200_000,
+    currentAmount: 300_000,
+    remainingAmount: 900_000,
+    progressPct: 25,
+    targetDate: '2026-12-31',
+    monthsRemaining: 5,
+    requiredMonthlyContribution: 180_000,
+    plannedMonthlyContribution: 100_000,
+    paceStatus: 'behind',
+    ...overrides,
+  }
+}
+
+export function makeRecurringIncome(
+  overrides?: Partial<SnapshotRecurringIncome>,
+): SnapshotRecurringIncome {
+  return {
+    id: 'rec-1',
+    description: 'Sueldo',
+    amount: 1_000_000,
+    currency: 'ARS',
+    dayOfMonth: 5,
+    pendingThisMonth: false,
+    ...overrides,
+  }
+}
+
+/** Cuotas futuras: un gasto CREDIT por mes indicado, ya materializado. */
+export function futureInstallmentExpenses(
+  entries: Array<{ month: string; amount: number; number?: number; total?: number }>,
+): SnapshotExpenseRow[] {
+  return entries.map((entry, index) =>
+    makeExpense({
+      date: `${entry.month}-10`,
+      amount: entry.amount,
+      category: 'Electrónica',
+      description: 'Compra en cuotas',
+      payment_method: 'CREDIT',
+      installment_number: entry.number ?? index + 2,
+      installment_total: entry.total ?? entries.length + 1,
+    }),
+  )
 }

--- a/lib/intelligence/__tests__/heroes.test.ts
+++ b/lib/intelligence/__tests__/heroes.test.ts
@@ -7,6 +7,7 @@ import {
   makeFreshUserSnapshot,
   makeInputs,
   makeSnapshot,
+  makeSubscription,
 } from './fixtures'
 
 describe('buildHeroesResponse', () => {
@@ -87,10 +88,21 @@ describe('pulse — ritmo del mes', () => {
     })
   })
 
-  it('con compromisos que superan el disponible el pulso queda sin margen', () => {
+  it('con metas y débitos que superan el disponible el pulso queda sin margen', () => {
     const response = buildHeroesResponse(
       makeSnapshot({
         disponibleReal: { ARS: 100_000, USD: 0 },
+        goals: { count: 1, committed: { ARS: 250_000, USD: 0 } },
+        subscriptions: [makeSubscription({ amount: 50_000, dayOfMonth: 20 })],
+      }),
+    )
+    expect(response.pulse?.spendable).toBe(-200_000)
+    expect(response.pulse?.dailyAmount).toBeNull()
+  })
+
+  it('los resúmenes pendientes no reducen el pulso: Disponible Real ya los descuenta', () => {
+    const response = buildHeroesResponse(
+      makeSnapshot({
         cards: [
           makeCard({
             pendingStatements: [
@@ -100,7 +112,7 @@ describe('pulse — ritmo del mes', () => {
         ],
       }),
     )
-    expect(response.pulse?.spendable).toBe(-200_000)
-    expect(response.pulse?.dailyAmount).toBeNull()
+    expect(response.pulse?.committedRemaining).toBe(0)
+    expect(response.pulse?.spendable).toBe(600_000)
   })
 })

--- a/lib/intelligence/__tests__/heroes.test.ts
+++ b/lib/intelligence/__tests__/heroes.test.ts
@@ -73,3 +73,34 @@ describe('buildHeroesResponse', () => {
     expect(response.heroes).toEqual([])
   })
 })
+
+describe('pulse — ritmo del mes', () => {
+  it('incluye el safe-to-spend diario para el mes en curso', () => {
+    const response = buildHeroesResponse(makeSnapshot())
+    // Disponible 600k sin compromisos ni metas, día 15 de 31 → 17 días restantes.
+    expect(response.pulse).toEqual({
+      spendable: 600_000,
+      dailyAmount: Math.floor(600_000 / 17),
+      daysLeft: 17,
+      committedRemaining: 0,
+      goalCommitted: 0,
+    })
+  })
+
+  it('con compromisos que superan el disponible el pulso queda sin margen', () => {
+    const response = buildHeroesResponse(
+      makeSnapshot({
+        disponibleReal: { ARS: 100_000, USD: 0 },
+        cards: [
+          makeCard({
+            pendingStatements: [
+              { periodMonth: '2026-06', amount: 300_000, dueDate: '2026-07-20', status: 'cerrado' },
+            ],
+          }),
+        ],
+      }),
+    )
+    expect(response.pulse?.spendable).toBe(-200_000)
+    expect(response.pulse?.dailyAmount).toBeNull()
+  })
+})

--- a/lib/intelligence/__tests__/insight-rules.test.ts
+++ b/lib/intelligence/__tests__/insight-rules.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from 'vitest'
 import { buildInsightCandidates } from '../insight-rules'
 import {
+  futureInstallmentExpenses,
   makeBudgetSnapshot,
   makeCard,
   makeExpense,
   makeFreshUserSnapshot,
+  makeGoal,
   makeInputs,
+  makeRecurringIncome,
   makeSnapshot,
+  makeSubscription,
+  MONTH,
 } from './fixtures'
 
 function kinds(snapshotCandidates: ReturnType<typeof buildInsightCandidates>): string[] {
@@ -268,5 +273,144 @@ describe('ranking por prioridad', () => {
     ])
     const priorities = candidates.map((candidate) => candidate.priority)
     expect([...priorities].sort((a, b) => b - a)).toEqual(priorities)
+  })
+})
+
+describe('installment_load', () => {
+  it('emite watch cuando un mes futuro compromete >=25% del ingreso', () => {
+    const candidates = buildInsightCandidates(
+      makeSnapshot({
+        futureExpenses: futureInstallmentExpenses([{ month: '2026-09', amount: 300_000 }]),
+      }),
+    )
+    const insight = candidates.find((candidate) => candidate.kind === 'installment_load')
+    expect(insight?.severity).toBe('watch')
+    expect(insight?.short).toContain('30%')
+  })
+
+  it('emite risk desde 40% del ingreso', () => {
+    const candidates = buildInsightCandidates(
+      makeSnapshot({
+        futureExpenses: futureInstallmentExpenses([{ month: '2026-08', amount: 450_000 }]),
+      }),
+    )
+    expect(candidates.find((candidate) => candidate.kind === 'installment_load')?.severity).toBe(
+      'risk',
+    )
+  })
+
+  it('con carga baja de cuotas no emite', () => {
+    const candidates = buildInsightCandidates(
+      makeSnapshot({
+        futureExpenses: futureInstallmentExpenses([{ month: '2026-08', amount: 100_000 }]),
+      }),
+    )
+    expect(kinds(candidates)).not.toContain('installment_load')
+  })
+})
+
+describe('wants_creep', () => {
+  it('emite watch cuando los deseos se despegan del histórico', () => {
+    const candidates = buildInsightCandidates(
+      makeSnapshot({
+        expenses: [
+          ...makeInputs().expenses,
+          makeExpense({
+            date: '2026-07-12',
+            amount: 100_000,
+            category: 'Ocio',
+            description: 'Escapada',
+            is_want: true,
+          }),
+        ],
+      }),
+    )
+    const insight = candidates.find((candidate) => candidate.kind === 'wants_creep')
+    expect(insight?.severity).toBe('watch')
+    expect(insight?.short).toContain('50%')
+  })
+
+  it('lado positivo: mes con menos deseos que de costumbre', () => {
+    const heavyWantsHistory = makeInputs().expenses.map((expense) =>
+      expense.date.startsWith(MONTH)
+        ? expense
+        : expense.category === 'Supermercado'
+          ? { ...expense, is_want: true }
+          : expense,
+    )
+    const candidates = buildInsightCandidates(makeSnapshot({ expenses: heavyWantsHistory }))
+    const insight = candidates.find((candidate) => candidate.kind === 'wants_creep')
+    expect(insight?.severity).toBe('positive')
+  })
+
+  it('el escenario base estable no emite wants_creep', () => {
+    expect(kinds(buildInsightCandidates(makeSnapshot()))).not.toContain('wants_creep')
+  })
+})
+
+describe('goal_pace', () => {
+  it('meta atrasada emite watch con el aporte necesario', () => {
+    const candidates = buildInsightCandidates(
+      makeSnapshot({ goalsDetail: [makeGoal()], goals: { count: 1, committed: { ARS: 0, USD: 0 } } }),
+    )
+    const insight = candidates.find((candidate) => candidate.kind === 'goal_pace')
+    expect(insight?.severity).toBe('watch')
+    expect(insight?.title).toContain('Viaje')
+    expect(insight?.message).toContain('/mes')
+  })
+
+  it('solo metas encaminadas emite señal positiva', () => {
+    const candidates = buildInsightCandidates(
+      makeSnapshot({
+        goalsDetail: [makeGoal({ paceStatus: 'on_track', progressPct: 60 })],
+        goals: { count: 1, committed: { ARS: 0, USD: 0 } },
+      }),
+    )
+    expect(candidates.find((candidate) => candidate.kind === 'goal_pace')?.severity).toBe(
+      'positive',
+    )
+  })
+})
+
+describe('income_missing', () => {
+  it('emite cuando el recurrente pasó su día habitual sin registrarse', () => {
+    const candidates = buildInsightCandidates(
+      makeSnapshot({
+        recurringIncomes: [makeRecurringIncome({ pendingThisMonth: true, dayOfMonth: 5 })],
+      }),
+    )
+    const insight = candidates.find((candidate) => candidate.kind === 'income_missing')
+    expect(insight?.severity).toBe('watch')
+    expect(insight?.title).toContain('Sueldo')
+  })
+
+  it('dentro del período de gracia no emite', () => {
+    const candidates = buildInsightCandidates(
+      makeSnapshot({
+        recurringIncomes: [makeRecurringIncome({ pendingThisMonth: true, dayOfMonth: 14 })],
+      }),
+    )
+    expect(kinds(candidates)).not.toContain('income_missing')
+  })
+})
+
+describe('subscription_load', () => {
+  it('emite info desde 12% del ingreso y watch desde 20%', () => {
+    const info = buildInsightCandidates(
+      makeSnapshot({ subscriptions: [makeSubscription({ amount: 150_000 })] }),
+    ).find((candidate) => candidate.kind === 'subscription_load')
+    expect(info?.severity).toBe('info')
+
+    const watch = buildInsightCandidates(
+      makeSnapshot({ subscriptions: [makeSubscription({ amount: 250_000 })] }),
+    ).find((candidate) => candidate.kind === 'subscription_load')
+    expect(watch?.severity).toBe('watch')
+  })
+
+  it('con peso bajo no emite', () => {
+    const candidates = buildInsightCandidates(
+      makeSnapshot({ subscriptions: [makeSubscription({ amount: 50_000 })] }),
+    )
+    expect(kinds(candidates)).not.toContain('subscription_load')
   })
 })

--- a/lib/intelligence/__tests__/insight-rules.test.ts
+++ b/lib/intelligence/__tests__/insight-rules.test.ts
@@ -190,10 +190,10 @@ describe('upcoming_card_due', () => {
 })
 
 describe('liquidity_watch', () => {
-  it('emite risk cuando el disponible no cubre los compromisos de 14 días', () => {
+  it('emite risk cuando el Saldo Vivo no cubre los compromisos de 14 días', () => {
     const candidates = buildInsightCandidates(
       makeSnapshot({
-        disponibleReal: { ARS: 200_000, USD: 0 },
+        saldoVivo: { ARS: 200_000, USD: 0 },
         cards: [
           makeCard({
             pendingStatements: [
@@ -208,7 +208,7 @@ describe('liquidity_watch', () => {
     expect(liquidity?.message).toContain('Visa Galicia')
   })
 
-  it('no emite cuando el disponible cubre lo comprometido', () => {
+  it('no emite cuando el Saldo Vivo cubre lo comprometido', () => {
     const candidates = buildInsightCandidates(
       makeSnapshot({
         cards: [

--- a/lib/intelligence/__tests__/projection.test.ts
+++ b/lib/intelligence/__tests__/projection.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeInstallmentHorizon,
+  computeMonthlyIncomeReference,
+  computeSafeToSpend,
+  simulatePurchase,
+} from '../projection'
+import {
+  futureInstallmentExpenses,
+  makeCard,
+  makeRecurringIncome,
+  makeSnapshot,
+  makeSubscription,
+} from './fixtures'
+
+describe('computeMonthlyIncomeReference', () => {
+  it('prioriza los ingresos recurrentes activos', () => {
+    const snapshot = makeSnapshot({
+      recurringIncomes: [
+        makeRecurringIncome({ amount: 900_000 }),
+        makeRecurringIncome({ id: 'rec-2', description: 'Freelance', amount: 300_000 }),
+      ],
+    })
+    expect(computeMonthlyIncomeReference(snapshot)).toEqual({
+      amount: 1_200_000,
+      source: 'recurring',
+    })
+  })
+
+  it('cae al promedio histórico cuando no hay recurrentes', () => {
+    expect(computeMonthlyIncomeReference(makeSnapshot())).toEqual({
+      amount: 1_000_000,
+      source: 'history',
+    })
+  })
+
+  it('sin recurrentes ni histórico devuelve null', () => {
+    const snapshot = makeSnapshot({ incomeEntries: [] })
+    expect(computeMonthlyIncomeReference(snapshot)).toEqual({ amount: null, source: null })
+  })
+})
+
+describe('computeInstallmentHorizon', () => {
+  it('agrega cuotas futuras por mes con peso sobre el ingreso', () => {
+    const snapshot = makeSnapshot({
+      futureExpenses: futureInstallmentExpenses([
+        { month: '2026-08', amount: 200_000 },
+        { month: '2026-09', amount: 300_000 },
+        { month: '2026-09', amount: 100_000 },
+      ]),
+    })
+    const horizon = computeInstallmentHorizon(snapshot)
+
+    expect(horizon.months).toEqual([
+      { month: '2026-08', amount: 200_000, count: 1, incomeSharePct: 20 },
+      { month: '2026-09', amount: 400_000, count: 2, incomeSharePct: 40 },
+    ])
+    expect(horizon.peak?.month).toBe('2026-09')
+    expect(horizon.dataQuality).toBe('ok')
+  })
+
+  it('sin cuotas futuras la calidad es insufficient', () => {
+    const horizon = computeInstallmentHorizon(makeSnapshot())
+    expect(horizon.months).toEqual([])
+    expect(horizon.peak).toBeNull()
+    expect(horizon.dataQuality).toBe('insufficient')
+  })
+})
+
+describe('computeSafeToSpend', () => {
+  it('resta compromisos del mes y metas del disponible', () => {
+    const snapshot = makeSnapshot({
+      disponibleReal: { ARS: 600_000, USD: 0 },
+      goals: { count: 1, committed: { ARS: 100_000, USD: 0 } },
+      cards: [
+        makeCard({
+          pendingStatements: [
+            { periodMonth: '2026-06', amount: 200_000, dueDate: '2026-07-20', status: 'cerrado' },
+          ],
+        }),
+      ],
+      subscriptions: [makeSubscription({ amount: 15_000, dayOfMonth: 20 })],
+    })
+    const safe = computeSafeToSpend(snapshot)
+
+    expect(safe.committedRemaining).toBe(215_000)
+    expect(safe.goalCommitted).toBe(100_000)
+    expect(safe.spendable).toBe(285_000)
+    // Día 15 de un mes de 31 → quedan 17 días contando hoy.
+    expect(safe.daysLeft).toBe(17)
+    expect(safe.dailyAmount).toBe(Math.floor(285_000 / 17))
+    expect(safe.dataQuality).toBe('ok')
+  })
+
+  it('un resumen que vence el mes que viene no presiona este mes, uno vencido sí', () => {
+    const snapshot = makeSnapshot({
+      cards: [
+        makeCard({
+          pendingStatements: [
+            { periodMonth: '2026-06', amount: 300_000, dueDate: '2026-08-05', status: 'cerrado' },
+            { periodMonth: '2026-05', amount: 50_000, dueDate: '2026-06-20', status: 'vencido' },
+          ],
+        }),
+      ],
+    })
+    const safe = computeSafeToSpend(snapshot)
+    expect(safe.committedRemaining).toBe(50_000)
+  })
+
+  it('las suscripciones con tarjeta no cuentan como salida de caja propia', () => {
+    const snapshot = makeSnapshot({
+      subscriptions: [makeSubscription({ paymentMethod: 'CREDIT', amount: 40_000 })],
+    })
+    expect(computeSafeToSpend(snapshot).committedRemaining).toBe(0)
+  })
+})
+
+describe('simulatePurchase', () => {
+  it('compra al contado que entra: veredicto positivo con margen restante', () => {
+    const simulation = simulatePurchase(makeSnapshot(), { amount: 250_000, installments: null })
+    expect(simulation.upfront).toEqual({
+      spendableAfter: 350_000,
+      dailyAfter: Math.floor(350_000 / 17),
+      fits: true,
+    })
+    expect(simulation.installmentPlan).toBeNull()
+  })
+
+  it('compra al contado que no entra', () => {
+    const simulation = simulatePurchase(makeSnapshot(), { amount: 700_000, installments: null })
+    expect(simulation.upfront?.fits).toBe(false)
+    expect(simulation.upfront?.spendableAfter).toBe(-100_000)
+  })
+
+  it('compra en cuotas: suma la cuota a la carga futura de cada mes', () => {
+    const snapshot = makeSnapshot({
+      futureExpenses: futureInstallmentExpenses([{ month: '2026-08', amount: 200_000 }]),
+    })
+    const simulation = simulatePurchase(snapshot, { amount: 600_000, installments: 6 })
+
+    expect(simulation.installmentPlan?.monthlyAmount).toBe(100_000)
+    expect(simulation.installmentPlan?.monthsAffected[0]).toEqual({
+      month: '2026-08',
+      newTotal: 300_000,
+      incomeSharePct: 30,
+    })
+    expect(simulation.installmentPlan?.monthsAffected[1]).toEqual({
+      month: '2026-09',
+      newTotal: 100_000,
+      incomeSharePct: 10,
+    })
+    expect(simulation.upfront).toBeNull()
+  })
+})

--- a/lib/intelligence/__tests__/projection.test.ts
+++ b/lib/intelligence/__tests__/projection.test.ts
@@ -68,43 +68,37 @@ describe('computeInstallmentHorizon', () => {
 })
 
 describe('computeSafeToSpend', () => {
-  it('resta compromisos del mes y metas del disponible', () => {
+  it('resta débitos del mes y metas del disponible', () => {
     const snapshot = makeSnapshot({
       disponibleReal: { ARS: 600_000, USD: 0 },
       goals: { count: 1, committed: { ARS: 100_000, USD: 0 } },
-      cards: [
-        makeCard({
-          pendingStatements: [
-            { periodMonth: '2026-06', amount: 200_000, dueDate: '2026-07-20', status: 'cerrado' },
-          ],
-        }),
-      ],
       subscriptions: [makeSubscription({ amount: 15_000, dayOfMonth: 20 })],
     })
     const safe = computeSafeToSpend(snapshot)
 
-    expect(safe.committedRemaining).toBe(215_000)
+    expect(safe.committedRemaining).toBe(15_000)
     expect(safe.goalCommitted).toBe(100_000)
-    expect(safe.spendable).toBe(285_000)
+    expect(safe.spendable).toBe(485_000)
     // Día 15 de un mes de 31 → quedan 17 días contando hoy.
     expect(safe.daysLeft).toBe(17)
-    expect(safe.dailyAmount).toBe(Math.floor(285_000 / 17))
+    expect(safe.dailyAmount).toBe(Math.floor(485_000 / 17))
     expect(safe.dataQuality).toBe('ok')
   })
 
-  it('un resumen que vence el mes que viene no presiona este mes, uno vencido sí', () => {
+  it('no vuelve a restar resúmenes de tarjeta: Disponible Real ya los descuenta', () => {
     const snapshot = makeSnapshot({
       cards: [
         makeCard({
           pendingStatements: [
-            { periodMonth: '2026-06', amount: 300_000, dueDate: '2026-08-05', status: 'cerrado' },
+            { periodMonth: '2026-06', amount: 200_000, dueDate: '2026-07-20', status: 'cerrado' },
             { periodMonth: '2026-05', amount: 50_000, dueDate: '2026-06-20', status: 'vencido' },
           ],
         }),
       ],
     })
     const safe = computeSafeToSpend(snapshot)
-    expect(safe.committedRemaining).toBe(50_000)
+    expect(safe.committedRemaining).toBe(0)
+    expect(safe.spendable).toBe(600_000)
   })
 
   it('las suscripciones con tarjeta no cuentan como salida de caja propia', () => {

--- a/lib/intelligence/chat-evidence.ts
+++ b/lib/intelligence/chat-evidence.ts
@@ -140,7 +140,7 @@ function buildBalancesFacts(snapshot: FinancialSnapshot): EvidenceItem[] {
     facts.push(
       evidenceItem(
         'Ritmo sugerido hasta fin de mes',
-        `${money(safe.dailyAmount, base)}/día por ${safe.daysLeft} días (queda ${money(safe.spendable, base)} libre tras compromisos y metas)`,
+        `${money(safe.dailyAmount, base)}/día por ${safe.daysLeft} días (queda ${money(safe.spendable, base)} libre tras débitos automáticos y metas; la deuda de tarjeta ya está descontada del disponible)`,
         'projection:safe_to_spend',
       ),
     )
@@ -663,7 +663,7 @@ function buildAffordabilityFacts(
   facts.push(
     evidenceItem(
       'Libre hasta fin de mes',
-      `${money(safe.spendable, currency)} (disponible ${money(safe.disponible, currency)} − compromisos del mes ${money(safe.committedRemaining, currency)} − metas ${money(safe.goalCommitted, currency)})`,
+      `${money(safe.spendable, currency)} (disponible ${money(safe.disponible, currency)} — que ya descuenta deuda de tarjeta — menos débitos del mes ${money(safe.committedRemaining, currency)} y metas ${money(safe.goalCommitted, currency)})`,
       'projection:spendable',
     ),
   )

--- a/lib/intelligence/chat-evidence.ts
+++ b/lib/intelligence/chat-evidence.ts
@@ -12,7 +12,6 @@ import {
 } from './evidence'
 import {
   computeBudgetPace,
-  computeGoalPace,
   computeSameDaySpend,
   computeUpcomingCardDues,
   computeWantsShare,

--- a/lib/intelligence/chat-evidence.ts
+++ b/lib/intelligence/chat-evidence.ts
@@ -2,13 +2,27 @@ import { addMonths } from '@/lib/dates'
 import { formatAmount } from '@/lib/format'
 import type { ChatIntent, ChatQueryPlan, MovementWindowKind } from './chat-planner'
 import { normalizeText } from './chat-planner'
-import { addDays, endOfMonth, evidenceItem, formatShortDate, moneyEvidence } from './evidence'
+import {
+  addDays,
+  endOfMonth,
+  evidenceItem,
+  formatMonthLabel,
+  formatShortDate,
+  moneyEvidence,
+} from './evidence'
 import {
   computeBudgetPace,
+  computeGoalPace,
   computeSameDaySpend,
   computeUpcomingCardDues,
+  computeWantsShare,
   getMonthProgress,
 } from './features'
+import {
+  computeInstallmentHorizon,
+  computeSafeToSpend,
+  simulatePurchase,
+} from './projection'
 import { buildInsightCandidates } from './insight-rules'
 import type {
   Currency,
@@ -67,6 +81,18 @@ const FOLLOW_UPS: Record<ChatIntent, string[]> = {
   ],
   yield_question: ['¿Cuánto me queda realmente disponible?', '¿Qué debería mirar hoy?'],
   goal_question: ['¿Cuánto me queda realmente disponible?', '¿Qué debería mirar hoy?'],
+  affordability: [
+    '¿Cuánto puedo gastar por día hasta fin de mes?',
+    '¿Qué compromisos fuertes tengo antes de fin de mes?',
+  ],
+  wants_question: [
+    '¿En qué estoy gastando más este mes?',
+    '¿Qué cambió vs meses anteriores a esta altura?',
+  ],
+  installment_question: [
+    '¿Cuánto me queda realmente disponible?',
+    '¿Me alcanza para una compra grande este mes?',
+  ],
   what_should_i_do: ['¿Dónde estoy pasado de presupuesto?', 'Mostrame movimientos grandes recientes'],
   general: ['¿Qué debería mirar hoy?', '¿En qué estoy gastando más este mes?'],
 }
@@ -108,6 +134,17 @@ function buildBalancesFacts(snapshot: FinancialSnapshot): EvidenceItem[] {
 
   for (const account of snapshot.accountBalances.slice(0, 5)) {
     facts.push(moneyEvidence(`Cuenta ${account.name}`, account.saldo, base, `account:${account.id}`))
+  }
+
+  const safe = computeSafeToSpend(snapshot)
+  if (safe.dataQuality === 'ok' && safe.dailyAmount !== null) {
+    facts.push(
+      evidenceItem(
+        'Ritmo sugerido hasta fin de mes',
+        `${money(safe.dailyAmount, base)}/día por ${safe.daysLeft} días (queda ${money(safe.spendable, base)} libre tras compromisos y metas)`,
+        'projection:safe_to_spend',
+      ),
+    )
   }
 
   return facts
@@ -495,15 +532,203 @@ function buildCategorySameDayFacts(
   return facts
 }
 
+const GOAL_PACE_LABEL: Record<string, string> = {
+  on_track: 'a ritmo',
+  behind: 'atrasada',
+  no_date: 'sin fecha objetivo',
+  completed: 'completada',
+  paused: 'pausada',
+}
+
 function buildGoalsFacts(snapshot: FinancialSnapshot): EvidenceItem[] {
   if (snapshot.goals.count === 0) {
     return [evidenceItem('Metas', 'Sin metas activas', 'goals:none')]
   }
   const base = snapshot.currency
-  return [
+  const facts: EvidenceItem[] = [
     evidenceItem('Metas activas', String(snapshot.goals.count), 'goals:count'),
     moneyEvidence('Comprometido en metas', snapshot.goals.committed[base], base, 'goals:committed'),
   ]
+
+  for (const goal of snapshot.goalsDetail.slice(0, 5)) {
+    if (goal.status === 'archived') continue
+    const parts = [
+      `${money(goal.currentAmount, goal.currency)} de ${money(goal.targetAmount, goal.currency)} (${goal.progressPct}%)`,
+      GOAL_PACE_LABEL[goal.paceStatus] ?? goal.paceStatus,
+    ]
+    if (goal.targetDate) parts.push(`objetivo ${formatShortDate(goal.targetDate)}`)
+    if (goal.paceStatus === 'behind' && goal.requiredMonthlyContribution) {
+      parts.push(`necesitás ${money(goal.requiredMonthlyContribution, goal.currency)}/mes`)
+    }
+    if (goal.plannedMonthlyContribution) {
+      parts.push(`aporte planificado ${money(goal.plannedMonthlyContribution, goal.currency)}/mes`)
+    }
+    facts.push(evidenceItem(`Meta ${goal.name}`, parts.join(' — '), `goal:${goal.id}`))
+  }
+
+  return facts
+}
+
+function buildWantsFacts(snapshot: FinancialSnapshot, caveats: string[]): EvidenceItem[] {
+  const feature = computeWantsShare(snapshot)
+  const currency = snapshot.currency
+  const facts: EvidenceItem[] = []
+
+  if (feature.currentWants > 0 && feature.currentSharePct !== null) {
+    facts.push(
+      evidenceItem(
+        'Deseos este mes a la fecha',
+        `${money(feature.currentWants, currency)} (${feature.currentSharePct}% de tu gasto de ${money(feature.currentSpend, currency)})`,
+        'wants:current',
+      ),
+    )
+  } else {
+    facts.push(evidenceItem('Deseos este mes', 'Sin gastos marcados como deseo', 'wants:current'))
+  }
+
+  if (feature.dataQuality === 'insufficient') {
+    caveats.push(
+      'No hay meses previos con gastos clasificados como deseo: no puedo comparar contra tu patrón habitual.',
+    )
+  } else if (feature.baselineSharePct !== null) {
+    facts.push(
+      evidenceItem(
+        'Peso habitual de deseos',
+        `${feature.baselineSharePct}% del gasto (promedio de ${feature.baselineMonths} meses)`,
+        'wants:baseline',
+      ),
+    )
+    if (feature.deltaPts !== null) {
+      facts.push(
+        evidenceItem(
+          'Diferencia vs tu patrón',
+          `${feature.deltaPts > 0 ? '+' : ''}${feature.deltaPts} puntos`,
+          'wants:delta',
+        ),
+      )
+    }
+  }
+
+  return facts
+}
+
+function buildInstallmentsFacts(snapshot: FinancialSnapshot, caveats: string[]): EvidenceItem[] {
+  const horizon = computeInstallmentHorizon(snapshot)
+  const currency = snapshot.currency
+
+  if (horizon.months.length === 0) {
+    caveats.push('No veo cuotas registradas para meses futuros.')
+    return [evidenceItem('Cuotas futuras', 'Ninguna registrada', 'installments:none')]
+  }
+
+  const facts: EvidenceItem[] = horizon.months.slice(0, 6).map((entry) =>
+    evidenceItem(
+      `Cuotas ${formatMonthLabel(entry.month)}`,
+      `${money(entry.amount, currency)} en ${entry.count} cuotas${entry.incomeSharePct !== null ? ` (${entry.incomeSharePct}% del ingreso)` : ''}`,
+      `installments:${entry.month}`,
+    ),
+  )
+
+  if (horizon.monthlyIncomeReference !== null) {
+    facts.push(
+      moneyEvidence(
+        `Ingreso mensual de referencia (${horizon.incomeReferenceSource === 'recurring' ? 'recurrentes' : 'promedio histórico'})`,
+        horizon.monthlyIncomeReference,
+        currency,
+        'income:reference',
+      ),
+    )
+  } else {
+    caveats.push(
+      'No hay ingreso de referencia (recurrentes o histórico), así que no puedo decir cuánto pesan las cuotas sobre tu ingreso.',
+    )
+  }
+
+  return facts
+}
+
+function buildAffordabilityFacts(
+  snapshot: FinancialSnapshot,
+  plan: ChatQueryPlan,
+  caveats: string[],
+): EvidenceItem[] {
+  const currency = snapshot.currency
+  const safe = computeSafeToSpend(snapshot)
+  const facts: EvidenceItem[] = []
+
+  if (safe.dataQuality !== 'ok') {
+    caveats.push('El ritmo diario solo se calcula para el mes en curso.')
+    return facts
+  }
+
+  facts.push(
+    evidenceItem(
+      'Libre hasta fin de mes',
+      `${money(safe.spendable, currency)} (disponible ${money(safe.disponible, currency)} − compromisos del mes ${money(safe.committedRemaining, currency)} − metas ${money(safe.goalCommitted, currency)})`,
+      'projection:spendable',
+    ),
+  )
+  if (safe.dailyAmount !== null) {
+    facts.push(
+      evidenceItem(
+        'Ritmo sugerido',
+        `${money(safe.dailyAmount, currency)}/día por los próximos ${safe.daysLeft} días`,
+        'projection:safe_to_spend',
+      ),
+    )
+  }
+
+  const { amount, installments } = plan.simulation
+  if (amount === null) {
+    caveats.push(
+      'No detecté un monto puntual en la pregunta: la respuesta usa tu margen general del mes.',
+    )
+    return facts
+  }
+
+  const simulation = simulatePurchase(snapshot, { amount, installments })
+
+  if (simulation.upfront) {
+    const { upfront } = simulation
+    facts.push(
+      evidenceItem(
+        `Simulación: gastar ${money(amount, currency)} ahora`,
+        upfront.fits
+          ? `Entra: te quedarían ${money(upfront.spendableAfter, currency)} libres${upfront.dailyAfter !== null ? ` (${money(upfront.dailyAfter, currency)}/día hasta fin de mes)` : ''}`
+          : `No entra sin tocar metas o compromisos: quedarías ${money(Math.abs(upfront.spendableAfter), currency)} abajo`,
+        'projection:simulation',
+      ),
+    )
+    facts.push(
+      evidenceItem(
+        'Veredicto',
+        upfront.fits ? 'La compra entra en el margen del mes' : 'La compra no entra en el margen del mes',
+        'projection:verdict',
+      ),
+    )
+  }
+
+  if (simulation.installmentPlan) {
+    const { installmentPlan } = simulation
+    facts.push(
+      evidenceItem(
+        `Simulación: ${money(amount, currency)} en ${installments} cuotas`,
+        `Cuota resultante ${money(installmentPlan.monthlyAmount, currency)}/mes`,
+        'projection:simulation',
+      ),
+    )
+    for (const month of installmentPlan.monthsAffected.slice(0, 4)) {
+      facts.push(
+        evidenceItem(
+          `Cuotas ${formatMonthLabel(month.month)} con esta compra`,
+          `${money(month.newTotal, currency)}${month.incomeSharePct !== null ? ` (${month.incomeSharePct}% del ingreso)` : ''}`,
+          `projection:simulation:${month.month}`,
+        ),
+      )
+    }
+  }
+
+  return facts
 }
 
 function buildYieldFacts(snapshot: FinancialSnapshot, caveats: string[]): EvidenceItem[] {
@@ -564,6 +789,7 @@ export function selectMovements(
   const matches = snapshot.movements.filter((movement) => {
     if (movement.date < from || movement.date > to) return false
     if (movementFilter.kind && movement.kind !== movementFilter.kind) return false
+    if (movementFilter.wantsOnly && movement.isWant !== true) return false
     return movementMatchesTerms(movement, movementFilter.terms)
   })
 
@@ -647,6 +873,15 @@ export function buildAnswerPacket(
         break
       case 'yield':
         facts.push(...buildYieldFacts(snapshot, caveats))
+        break
+      case 'wants':
+        facts.push(...buildWantsFacts(snapshot, caveats))
+        break
+      case 'installments':
+        facts.push(...buildInstallmentsFacts(snapshot, caveats))
+        break
+      case 'affordability':
+        facts.push(...buildAffordabilityFacts(snapshot, plan, caveats))
         break
       case 'insights':
         insights = buildInsightCandidates(snapshot)

--- a/lib/intelligence/chat-planner.ts
+++ b/lib/intelligence/chat-planner.ts
@@ -9,6 +9,9 @@ export type ChatIntent =
   | 'subscription_question'
   | 'yield_question'
   | 'goal_question'
+  | 'affordability'
+  | 'wants_question'
+  | 'installment_question'
   | 'what_should_i_do'
   | 'general'
 
@@ -23,6 +26,9 @@ export type PacketSection =
   | 'goals'
   | 'yield'
   | 'insights'
+  | 'affordability'
+  | 'wants'
+  | 'installments'
 
 export type MovementWindowKind =
   | 'today'
@@ -40,8 +46,14 @@ export type ChatQueryPlan = {
     terms: string[]
     largeOnly: boolean
     kind: 'gasto' | 'ingreso' | null
+    wantsOnly: boolean
     window: MovementWindowKind
     limit: number
+  }
+  /** Monto y cuotas detectados para simular una compra ("¿me alcanza?"). */
+  simulation: {
+    amount: number | null
+    installments: number | null
   }
 }
 
@@ -87,13 +99,37 @@ const INTENT_MATCHERS: Array<{ intent: ChatIntent; patterns: RegExp[] }> = [
     ],
   },
   {
+    intent: 'affordability',
+    patterns: [
+      /me alcanza/,
+      /puedo (comprar|gastar|pagar|permitirme|darme)/,
+      /me da (para|el cuero)/,
+      /si (compro|gasto|pago)\b/,
+      /cuanto puedo gastar/,
+      /entra en (mi|el) (mes|presupuesto|bolsillo)/,
+      /conviene comprar/,
+    ],
+  },
+  {
+    intent: 'wants_question',
+    // "deseo" solo cuenta como sustantivo ("en deseos"), no "deseo saber...".
+    patterns: [
+      /\bdeseos\b/, /\ben deseo\b/, /gast(o|e|ando).*deseo/, /antojo/, /caprich/,
+      /impulsiv/, /darme (un|el) gusto/, /\bgustos\b/, /necesidad (vs|versus|o) deseo/,
+    ],
+  },
+  {
+    intent: 'installment_question',
+    patterns: [/cuota/, /financiaci/, /financiado/, /comprometido para (los|el)/],
+  },
+  {
     intent: 'budget_question',
     patterns: [/presupuest/, /pasado de/, /me pase (de|con)/, /\btope\b/, /\blimite\b/],
   },
   {
     intent: 'card_commitments',
     patterns: [
-      /tarjeta/, /resumen/, /vencimiento/, /\bvence\b/, /compromiso/, /cuota/,
+      /tarjeta/, /resumen/, /vencimiento/, /\bvence\b/, /compromiso/,
       /\bvisa\b/, /\bmaster(card)?\b/, /\bamex\b/, /debo pagar/,
     ],
   },
@@ -177,8 +213,66 @@ const SECTIONS_BY_INTENT: Record<ChatIntent, PacketSection[]> = {
   subscription_question: ['subscriptions'],
   yield_question: ['yield', 'balances'],
   goal_question: ['goals', 'balances'],
+  affordability: ['affordability', 'balances', 'commitments'],
+  wants_question: ['wants', 'categories'],
+  installment_question: ['installments', 'commitments'],
   what_should_i_do: ['insights', 'balances', 'budget', 'commitments'],
   general: ['balances', 'categories', 'trend', 'budget', 'commitments'],
+}
+
+// ─── Extracción de monto y cuotas para simulaciones ──────────────────────────
+
+const INSTALLMENTS_PATTERN = /(\d{1,2})\s*cuotas?/
+
+function parseAmountToken(token: string, suffix: string | undefined): number | null {
+  let value: number
+  if (/^\d{1,3}(\.\d{3})+$/.test(token)) {
+    value = Number(token.replace(/\./g, ''))
+  } else if (/^\d+,\d{1,2}$/.test(token)) {
+    value = Number(token.replace(',', '.'))
+  } else if (/^\d+$/.test(token)) {
+    value = Number(token)
+  } else {
+    return null
+  }
+  if (!Number.isFinite(value) || value <= 0) return null
+
+  if (suffix === 'k' || suffix === 'mil' || suffix === 'lucas') return value * 1_000
+  if (suffix === 'palo' || suffix === 'palos') return value * 1_000_000
+  return value
+}
+
+/**
+ * Detecta monto y cantidad de cuotas en la pregunta ("¿me alcanza para algo
+ * de 250 lucas en 6 cuotas?"). Determinístico; devuelve null si no hay monto
+ * inequívoco.
+ */
+export function extractSimulation(question: string): {
+  amount: number | null
+  installments: number | null
+} {
+  const normalized = normalizeText(question)
+  const installmentsMatch = normalized.match(INSTALLMENTS_PATTERN)
+  const installments = installmentsMatch ? Number(installmentsMatch[1]) : null
+  // El número de cuotas no debe confundirse con el monto.
+  const withoutInstallments = installmentsMatch
+    ? normalized.replace(installmentsMatch[0], ' ')
+    : normalized
+
+  const amounts: number[] = []
+  const pattern = /(\d[\d.,]*)\s*(k|mil|lucas|palos?)?\b/g
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(withoutInstallments)) !== null) {
+    const parsed = parseAmountToken(match[1].replace(/[.,]$/, ''), match[2])
+    if (parsed !== null) amounts.push(parsed)
+  }
+
+  // Montos de una compra real: se descartan números chicos sueltos (días, cantidades).
+  const candidates = amounts.filter((amount) => amount >= 1_000)
+  return {
+    amount: candidates.length > 0 ? Math.max(...candidates) : null,
+    installments: installments && installments > 1 ? installments : null,
+  }
 }
 
 function detectWindow(normalized: string): MovementWindowKind {
@@ -205,7 +299,10 @@ export function planChatQuery(question: string): ChatQueryPlan {
 
   const includeMovements =
     intent === 'movement_lookup' ||
+    intent === 'wants_question' ||
     (intent === 'general' && extractSearchTerms(question).length > 0)
+
+  const wantsOnly = intent === 'wants_question'
 
   return {
     intent,
@@ -221,9 +318,12 @@ export function planChatQuery(question: string): ChatQueryPlan {
           ? extractSearchTerms(question)
           : [],
       largeOnly,
-      kind,
-      window: detectWindow(normalized),
-      limit: largeOnly ? 8 : 12,
+      kind: wantsOnly ? 'gasto' : kind,
+      wantsOnly,
+      window: wantsOnly && detectWindow(normalized) === 'recent' ? 'this_month' : detectWindow(normalized),
+      limit: largeOnly || wantsOnly ? 8 : 12,
     },
+    simulation:
+      intent === 'affordability' ? extractSimulation(question) : { amount: null, installments: null },
   }
 }

--- a/lib/intelligence/chat-prompt.ts
+++ b/lib/intelligence/chat-prompt.ts
@@ -61,6 +61,7 @@ Reglas de confianza (no negociables):
 - No hagas contabilidad nueva: podés citar y comparar los números provistos, no derivar otros.
 - Si la pregunta pide algo que no está en los datos, decilo claro y sugerí qué mirar en la app.
 - Si hay limitaciones listadas que afectan la respuesta, mencionalas en una frase.
+- Si hay un "Veredicto" o una "Simulación" en los hechos, esa es la respuesta: citala tal cual, no la recalcules ni la contradigas.
 - Si el usuario pide crear, editar o borrar movimientos, explicá que esta versión es solo de lectura.
 
 Estilo:
@@ -69,6 +70,8 @@ Estilo:
 - Si hay datos útiles, no abras con una limitación. Mencioná limitaciones solo después y solo si cambian la conclusión.
 - Para preguntas de promedio histórico o presupuesto por categoría, priorizá: promedio mensual, mes actual vs promedio, rango/meses usados y recomendación prudente de planificación.
 - Para preguntas "a esta altura" sobre una categoría, priorizá la comparativa al mismo día; mencioná el promedio mensual completo solo como contexto separado.
+- Para preguntas sobre deseos/gustos: describí el dato y la comparación, sin juicio de valor. Darse gustos no es un problema a corregir.
+- Para "¿me alcanza?": abrí con el veredicto, después el porqué (margen libre, ritmo diario o carga de cuotas).
 - No mezcles totales de meses cerrados con comparaciones "a esta altura" sin etiquetarlos explícitamente como scopes distintos.
 - Máximo 4-5 oraciones, salvo que haya que enumerar movimientos (lista corta, una línea por movimiento).
 - No uses tablas markdown ni encabezados.

--- a/lib/intelligence/evidence.ts
+++ b/lib/intelligence/evidence.ts
@@ -26,6 +26,12 @@ export function formatShortDate(date: string): string {
   return `${day} ${SHORT_MONTHS_ES[monthIndex] ?? ''}`.trim()
 }
 
+/** '2026-10' → 'oct 2026' */
+export function formatMonthLabel(month: string): string {
+  const monthIndex = Number(month.substring(5, 7)) - 1
+  return `${SHORT_MONTHS_ES[monthIndex] ?? month} ${month.substring(0, 4)}`.trim()
+}
+
 /** Días de diferencia entre dos fechas YYYY-MM-DD (positivo si to > from). */
 export function diffDays(from: string, to: string): number {
   const parse = (value: string) => {

--- a/lib/intelligence/features.ts
+++ b/lib/intelligence/features.ts
@@ -3,8 +3,10 @@ import { addDays, diffDays } from './evidence'
 import type {
   DataQuality,
   FinancialSnapshot,
+  SnapshotGoal,
   SnapshotMovement,
   SnapshotPendingStatement,
+  SnapshotRecurringIncome,
 } from './types'
 
 // ─── Progreso del mes ────────────────────────────────────────────────────────
@@ -32,6 +34,8 @@ export type SameDaySpendFeature = {
   baselineKind: 'previous_month' | 'rolling_average' | null
   baselineWindow: number
   deltaPct: number | null
+  /** Gasto extraordinario del mes en curso excluido de la comparación. */
+  extraordinaryExcluded: number
   dataQuality: DataQuality
 }
 
@@ -45,10 +49,36 @@ function comparablePreviousPoints(snapshot: FinancialSnapshot): MonthlySeriesPoi
   )
 }
 
+/**
+ * Gasto extraordinario acumulado hasta el día comparable, por mes (moneda
+ * base). Se resta del gasto observado y de los baselines: un gasto que el
+ * usuario marcó como extraordinario no debe distorsionar el ritmo habitual.
+ */
+function sameDayExtraordinaryByMonth(snapshot: FinancialSnapshot): Map<string, number> {
+  const comparisonDay = snapshot.comparisonDay ?? snapshot.dayOfMonth
+  const totals = new Map<string, number>()
+  for (const movement of snapshot.movements) {
+    if (movement.kind !== 'gasto' || movement.isCardPayment) continue
+    if (!movement.isExtraordinary) continue
+    if (movement.currency !== snapshot.currency) continue
+    if (Number(movement.date.slice(8, 10)) > comparisonDay) continue
+    const month = movement.date.substring(0, 7)
+    totals.set(month, (totals.get(month) ?? 0) + movement.amount)
+  }
+  return totals
+}
+
 export function computeSameDaySpend(snapshot: FinancialSnapshot): SameDaySpendFeature {
   const selectedPoint =
     snapshot.monthlySeries.find((point) => point.month === snapshot.month) ?? null
-  const currentAmount = selectedPoint?.sameDayPercibidoDevengadoTotal ?? 0
+  const extraordinaryByMonth = sameDayExtraordinaryByMonth(snapshot)
+  const extraordinaryExcluded = extraordinaryByMonth.get(snapshot.month) ?? 0
+  const adjust = (month: string, value: number | null): number | null => {
+    if (value === null) return null
+    return Math.max(0, value - (extraordinaryByMonth.get(month) ?? 0))
+  }
+  const currentAmount =
+    adjust(snapshot.month, selectedPoint?.sameDayPercibidoDevengadoTotal ?? 0) ?? 0
   const previousPoints = comparablePreviousPoints(snapshot)
 
   const insufficient: SameDaySpendFeature = {
@@ -57,6 +87,7 @@ export function computeSameDaySpend(snapshot: FinancialSnapshot): SameDaySpendFe
     baselineKind: null,
     baselineWindow: 0,
     deltaPct: null,
+    extraordinaryExcluded,
     dataQuality: 'insufficient',
   }
 
@@ -66,7 +97,7 @@ export function computeSameDaySpend(snapshot: FinancialSnapshot): SameDaySpendFe
 
   if (previousPoints.length <= 2) {
     const previous = previousPoints[previousPoints.length - 1]
-    const baselineAmount = previous.sameDayPercibidoDevengadoTotal
+    const baselineAmount = adjust(previous.month, previous.sameDayPercibidoDevengadoTotal)
     if (baselineAmount === null || baselineAmount <= 0) return insufficient
     return {
       currentAmount,
@@ -74,6 +105,7 @@ export function computeSameDaySpend(snapshot: FinancialSnapshot): SameDaySpendFe
       baselineKind: 'previous_month',
       baselineWindow: 1,
       deltaPct: Math.round(((currentAmount - baselineAmount) / baselineAmount) * 100),
+      extraordinaryExcluded,
       dataQuality: 'partial',
     }
   }
@@ -81,7 +113,7 @@ export function computeSameDaySpend(snapshot: FinancialSnapshot): SameDaySpendFe
   const windowSize = Math.min(previousPoints.length, 6)
   const values = previousPoints
     .slice(-windowSize)
-    .map((point) => point.sameDayPercibidoDevengadoTotal)
+    .map((point) => adjust(point.month, point.sameDayPercibidoDevengadoTotal))
     .filter((value): value is number => value !== null && value > 0)
   if (values.length === 0) return insufficient
 
@@ -92,6 +124,7 @@ export function computeSameDaySpend(snapshot: FinancialSnapshot): SameDaySpendFe
     baselineKind: 'rolling_average',
     baselineWindow: values.length,
     deltaPct: Math.round(((currentAmount - baselineAmount) / baselineAmount) * 100),
+    extraordinaryExcluded,
     dataQuality: 'ok',
   }
 }
@@ -176,7 +209,7 @@ export type LiquidityFeature = {
   items: UpcomingCommitmentItem[]
 }
 
-function nextSubscriptionDate(snapshot: FinancialSnapshot, dayOfMonth: number): string {
+export function nextSubscriptionDate(snapshot: FinancialSnapshot, dayOfMonth: number): string {
   const clamp = (month: string, day: number) => {
     const [year, monthNumber] = month.split('-').map(Number)
     const lastDay = new Date(year, monthNumber, 0).getDate()
@@ -245,16 +278,17 @@ export function computeUnusualMovements(
   const windowStart = addDays(snapshot.referenceDate, -(withinDays - 1))
 
   // Baseline por categoría con meses previos completos (moneda base).
+  // Los gastos marcados extraordinarios no forman parte del ticket habitual.
   const baselines = new Map<string, { amount: number; count: number }>()
-  for (const aggregate of snapshot.monthAggregates) {
-    if (aggregate.month >= snapshot.month) continue
-    for (const category of aggregate.categories) {
-      if (category.currency !== snapshot.currency) continue
-      const current = baselines.get(category.category) ?? { amount: 0, count: 0 }
-      current.amount += category.amount
-      current.count += category.count
-      baselines.set(category.category, current)
-    }
+  for (const movement of snapshot.movements) {
+    if (movement.kind !== 'gasto' || movement.isCardPayment) continue
+    if (movement.currency !== snapshot.currency) continue
+    if (movement.date.substring(0, 7) >= snapshot.month) continue
+    if (movement.isExtraordinary) continue
+    const current = baselines.get(movement.category) ?? { amount: 0, count: 0 }
+    current.amount += movement.amount
+    current.count += 1
+    baselines.set(movement.category, current)
   }
 
   const income = snapshot.monthIncome[snapshot.currency]
@@ -272,6 +306,8 @@ export function computeUnusualMovements(
     if (movement.kind !== 'gasto' || movement.isCardPayment) continue
     if (movement.currency !== snapshot.currency) continue
     if (movement.date < windowStart || movement.date > snapshot.referenceDate) continue
+    // Un gasto que el usuario ya marcó como extraordinario no es novedad.
+    if (movement.isExtraordinary) continue
 
     const baseline = baselines.get(movement.category)
     if (!baseline || baseline.count < minHistoricalCount) continue
@@ -292,4 +328,122 @@ export function computeUnusualMovements(
   }
 
   return results.sort((a, b) => b.multiple - a.multiple)
+}
+
+// ─── Deseo vs necesidad ──────────────────────────────────────────────────────
+
+export type WantsShareFeature = {
+  currentWants: number
+  currentSpend: number
+  currentSharePct: number | null
+  baselineSharePct: number | null
+  baselineMonths: number
+  deltaPts: number | null
+  dataQuality: DataQuality
+}
+
+/** Gasto propio del mes (percibido sin pagos de tarjeta + devengado). */
+function ownSpendOfMonth(
+  aggregate: FinancialSnapshot['monthAggregates'][number],
+  currency: FinancialSnapshot['currency'],
+): number {
+  return (
+    aggregate.perceivedSpend[currency] -
+    aggregate.cardPayments[currency] +
+    aggregate.accruedSpend[currency]
+  )
+}
+
+export function computeWantsShare(snapshot: FinancialSnapshot): WantsShareFeature {
+  const currency = snapshot.currency
+  const current = snapshot.monthAggregates.find((aggregate) => aggregate.month === snapshot.month)
+  const currentSpend = current ? ownSpendOfMonth(current, currency) : 0
+  const currentWants = current?.wantsSpend[currency] ?? 0
+  const currentSharePct =
+    currentSpend > 0 ? Math.round((currentWants / currentSpend) * 100) : null
+
+  const closedMonths = snapshot.monthAggregates.filter(
+    (aggregate) => aggregate.month < snapshot.month && ownSpendOfMonth(aggregate, currency) > 0,
+  )
+  const monthsWithWants = closedMonths.filter(
+    (aggregate) => aggregate.wantsSpend[currency] > 0,
+  ).length
+
+  // Sin meses previos clasificados con deseo no hay línea base honesta:
+  // un histórico todo en 0 suele significar "no clasifica", no "no gasta en deseos".
+  if (closedMonths.length === 0 || monthsWithWants === 0) {
+    return {
+      currentWants,
+      currentSpend,
+      currentSharePct,
+      baselineSharePct: null,
+      baselineMonths: 0,
+      deltaPts: null,
+      dataQuality: 'insufficient',
+    }
+  }
+
+  const baselineSharePct = Math.round(
+    (closedMonths.reduce(
+      (sum, aggregate) =>
+        sum + aggregate.wantsSpend[currency] / ownSpendOfMonth(aggregate, currency),
+      0,
+    ) /
+      closedMonths.length) *
+      100,
+  )
+
+  return {
+    currentWants,
+    currentSpend,
+    currentSharePct,
+    baselineSharePct,
+    baselineMonths: closedMonths.length,
+    deltaPts: currentSharePct !== null ? currentSharePct - baselineSharePct : null,
+    dataQuality: closedMonths.length >= 3 ? 'ok' : 'partial',
+  }
+}
+
+// ─── Ritmo de metas ──────────────────────────────────────────────────────────
+
+export type GoalPaceFeature = {
+  behind: SnapshotGoal[]
+  onTrack: SnapshotGoal[]
+}
+
+const byNearestTarget = (a: SnapshotGoal, b: SnapshotGoal) =>
+  (a.targetDate ?? '9999-12-31').localeCompare(b.targetDate ?? '9999-12-31')
+
+export function computeGoalPace(snapshot: FinancialSnapshot): GoalPaceFeature {
+  const active = snapshot.goalsDetail.filter((goal) => goal.status === 'active')
+  return {
+    behind: active
+      .filter(
+        (goal) =>
+          goal.paceStatus === 'behind' &&
+          goal.targetDate !== null &&
+          goal.requiredMonthlyContribution !== null &&
+          goal.requiredMonthlyContribution > 0,
+      )
+      .sort(byNearestTarget),
+    onTrack: active
+      .filter((goal) => goal.paceStatus === 'on_track' && goal.progressPct > 0)
+      .sort(byNearestTarget),
+  }
+}
+
+// ─── Ingresos recurrentes que no llegaron ────────────────────────────────────
+
+export function computeMissingIncomes(
+  snapshot: FinancialSnapshot,
+  graceDays = 2,
+): SnapshotRecurringIncome[] {
+  // Solo aplica al mes en curso: en meses pasados el pendiente no es accionable.
+  if (snapshot.comparisonDay === null) return []
+  return snapshot.recurringIncomes
+    .filter(
+      (income) =>
+        income.pendingThisMonth && snapshot.dayOfMonth >= income.dayOfMonth + graceDays,
+    )
+    .sort((a, b) => b.amount - a.amount)
 }

--- a/lib/intelligence/features.ts
+++ b/lib/intelligence/features.ts
@@ -203,7 +203,8 @@ export type UpcomingCommitmentItem = {
 }
 
 export type LiquidityFeature = {
-  disponible: number
+  /** Saldo Vivo en moneda base: la caja real contra la que se mide lo que vence. */
+  saldo: number
   upcomingTotal: number
   gap: number
   items: UpcomingCommitmentItem[]
@@ -254,9 +255,12 @@ export function computeLiquidity(snapshot: FinancialSnapshot, withinDays = 14): 
 
   items.sort((a, b) => a.date.localeCompare(b.date))
   const upcomingTotal = items.reduce((sum, item) => sum + item.amount, 0)
-  const disponible = snapshot.disponibleReal[snapshot.currency]
+  // La pregunta de liquidez es de caja: ¿la plata que hay cubre lo que vence?
+  // Se mide contra Saldo Vivo. Disponible Real no sirve de base acá porque ya
+  // descuenta los resúmenes de tarjeta que este cálculo suma como compromisos.
+  const saldo = snapshot.saldoVivo[snapshot.currency]
 
-  return { disponible, upcomingTotal, gap: disponible - upcomingTotal, items }
+  return { saldo, upcomingTotal, gap: saldo - upcomingTotal, items }
 }
 
 // ─── Movimientos fuera de patrón ─────────────────────────────────────────────

--- a/lib/intelligence/heroes.ts
+++ b/lib/intelligence/heroes.ts
@@ -1,4 +1,5 @@
 import { buildInsightCandidates } from './insight-rules'
+import { computeSafeToSpend } from './projection'
 import type {
   Currency,
   EvidenceItem,
@@ -18,11 +19,21 @@ export type IntelligenceHero = {
   cta?: InsightAction
 }
 
+/** Ritmo del mes: cuánto queda libre por día tras compromisos y metas. */
+export type IntelligencePulse = {
+  spendable: number
+  dailyAmount: number | null
+  daysLeft: number
+  committedRemaining: number
+  goalCommitted: number
+}
+
 export type IntelligenceHeroResponse = {
   generatedAt: string
   month: string
   currency: Currency
   heroes: IntelligenceHero[]
+  pulse: IntelligencePulse | null
 }
 
 const MAX_HEROES = 4
@@ -38,11 +49,23 @@ export function buildHeroesResponse(
 ): IntelligenceHeroResponse {
   const maxHeroes = options?.maxHeroes ?? MAX_HEROES
   const candidates = buildInsightCandidates(snapshot)
+  const safeToSpend = computeSafeToSpend(snapshot)
+  const pulse: IntelligencePulse | null =
+    safeToSpend.dataQuality === 'ok'
+      ? {
+          spendable: Math.round(safeToSpend.spendable),
+          dailyAmount: safeToSpend.dailyAmount,
+          daysLeft: safeToSpend.daysLeft,
+          committedRemaining: Math.round(safeToSpend.committedRemaining),
+          goalCommitted: Math.round(safeToSpend.goalCommitted),
+        }
+      : null
 
   return {
     generatedAt: options?.generatedAt ?? new Date().toISOString(),
     month: snapshot.month,
     currency: snapshot.currency,
+    pulse,
     heroes: candidates.slice(0, maxHeroes).map((candidate) => ({
       id: candidate.id,
       kind: candidate.kind,

--- a/lib/intelligence/insight-rules.ts
+++ b/lib/intelligence/insight-rules.ts
@@ -3,18 +3,23 @@ import {
   addDays,
   endOfMonth,
   evidenceItem,
+  formatMonthLabel,
   formatShortDate,
   moneyEvidence,
   relativeDayLabel,
 } from './evidence'
 import {
   computeBudgetPace,
+  computeGoalPace,
   computeLiquidity,
+  computeMissingIncomes,
   computeSameDaySpend,
   computeUnusualMovements,
   computeUpcomingCardDues,
+  computeWantsShare,
   getMonthProgress,
 } from './features'
+import { computeInstallmentHorizon, computeMonthlyIncomeReference } from './projection'
 import type { FinancialSnapshot, InsightCandidate, InsightSeverity } from './types'
 
 const SEVERITY_WEIGHT: Record<InsightSeverity, number> = {
@@ -96,6 +101,10 @@ function ruleSameDaySpendDelta(snapshot: FinancialSnapshot): InsightCandidate | 
     feature.baselineKind === 'previous_month'
       ? 'el mes pasado a esta altura'
       : `tu promedio ${feature.baselineWindow}m a esta altura`
+  const extraordinaryNote =
+    feature.extraordinaryExcluded > 0
+      ? ` No cuenta ${formatAmount(feature.extraordinaryExcluded, currency)} marcados como extraordinarios.`
+      : ''
 
   return {
     id: `same_day_spend_delta:${snapshot.month}:${snapshot.referenceDate}`,
@@ -106,7 +115,7 @@ function ruleSameDaySpendDelta(snapshot: FinancialSnapshot): InsightCandidate | 
       ? `Vas ${Math.abs(feature.deltaPct)}% abajo de tu ritmo habitual`
       : `Vas ${feature.deltaPct}% arriba de tu ritmo habitual`,
     short: `Gasto al día ${snapshot.dayOfMonth}: ${formatAmount(feature.currentAmount, currency)} (${feature.deltaPct > 0 ? '+' : ''}${feature.deltaPct}%)`,
-    message: `Al día ${snapshot.dayOfMonth} llevás ${formatAmount(feature.currentAmount, currency)} en gastos observados; ${baselineLabel} eran ${formatAmount(Math.round(feature.baselineAmount), currency)}.`,
+    message: `Al día ${snapshot.dayOfMonth} llevás ${formatAmount(feature.currentAmount, currency)} en gastos observados; ${baselineLabel} eran ${formatAmount(Math.round(feature.baselineAmount), currency)}.${extraordinaryNote}`,
     evidence: [
       moneyEvidence('Gasto a hoy', feature.currentAmount, currency, 'monthly_series:same_day'),
       moneyEvidence(
@@ -245,6 +254,218 @@ function ruleRecentUnusualMovement(snapshot: FinancialSnapshot): InsightCandidat
   }
 }
 
+// ─── installment_load ────────────────────────────────────────────────────────
+// Mes futuro con demasiado ingreso ya comprometido en cuotas.
+
+function ruleInstallmentLoad(snapshot: FinancialSnapshot): InsightCandidate | null {
+  const horizon = computeInstallmentHorizon(snapshot)
+  if (horizon.dataQuality !== 'ok' || !horizon.peak) return null
+  const { peak } = horizon
+  if (peak.incomeSharePct === null || peak.incomeSharePct < 25) return null
+
+  const currency = snapshot.currency
+  const severity: InsightSeverity = peak.incomeSharePct >= 40 ? 'risk' : 'watch'
+  const monthLabel = formatMonthLabel(peak.month)
+  const monthsWithLoad = horizon.months.length
+
+  return {
+    id: `installment_load:${snapshot.month}:${peak.month}`,
+    kind: 'installment_load',
+    severity,
+    priority: SEVERITY_WEIGHT[severity] + clamp(peak.incomeSharePct - 25, 0, 30),
+    title: `${monthLabel} ya arranca con ${peak.incomeSharePct}% del ingreso en cuotas`,
+    short: `Cuotas de ${monthLabel}: ${formatAmount(peak.amount, currency)} (${peak.incomeSharePct}% del ingreso)`,
+    message: `Tus compras en cuotas ya comprometen ${formatAmount(peak.amount, currency)} para ${monthLabel} (${peak.count} cuotas, ${peak.incomeSharePct}% de tu ingreso de referencia). Tenés cuotas cayendo en ${monthsWithLoad} de los próximos 6 meses.`,
+    evidence: [
+      moneyEvidence(`Cuotas ${monthLabel}`, peak.amount, currency, `installments:${peak.month}`),
+      moneyEvidence(
+        'Ingreso de referencia',
+        horizon.monthlyIncomeReference ?? 0,
+        currency,
+        `income:${horizon.incomeReferenceSource}`,
+      ),
+      evidenceItem('Peso sobre ingreso', `${peak.incomeSharePct}%`, `installments:${peak.month}`),
+    ],
+    dataQuality: 'ok',
+    actions: [
+      { label: 'Ver cuotas futuras', question: '¿Cómo vienen mis cuotas de los próximos meses?' },
+    ],
+    validUntil: endOfMonth(snapshot.month),
+    dedupeKey: `installment_load:${peak.month}`,
+  }
+}
+
+// ─── wants_creep ─────────────────────────────────────────────────────────────
+// El share de gasto en deseos del mes se despega del promedio histórico.
+
+function ruleWantsCreep(snapshot: FinancialSnapshot): InsightCandidate | null {
+  const feature = computeWantsShare(snapshot)
+  if (feature.dataQuality === 'insufficient') return null
+  if (feature.deltaPts === null || feature.currentSharePct === null) return null
+  if (Math.abs(feature.deltaPts) < 12) return null
+
+  const currency = snapshot.currency
+  const isPositive = feature.deltaPts <= -12
+  // Subas chicas en plata no ameritan señal aunque el share salte.
+  if (!isPositive && feature.currentWants < feature.currentSpend * 0.15) return null
+
+  const severity: InsightSeverity = isPositive ? 'positive' : 'watch'
+
+  return {
+    id: `wants_creep:${snapshot.month}`,
+    kind: 'wants_creep',
+    severity,
+    priority: SEVERITY_WEIGHT[severity] + clamp(Math.abs(feature.deltaPts), 0, 25),
+    title: isPositive
+      ? 'Este mes estás gastando menos en deseos'
+      : 'Los deseos pesan más que de costumbre',
+    short: `Deseos: ${feature.currentSharePct}% del gasto (venías en ${feature.baselineSharePct}%)`,
+    message: isPositive
+      ? `Llevás ${formatAmount(feature.currentWants, currency)} en deseos, el ${feature.currentSharePct}% de tu gasto del mes; tu promedio de los últimos ${feature.baselineMonths} meses era ${feature.baselineSharePct}%.`
+      : `Llevás ${formatAmount(feature.currentWants, currency)} en deseos, el ${feature.currentSharePct}% de tu gasto del mes. En tus últimos ${feature.baselineMonths} meses ese peso venía siendo ${feature.baselineSharePct}%.`,
+    evidence: [
+      moneyEvidence('Deseos este mes', feature.currentWants, currency, 'wants:current'),
+      evidenceItem('Peso en el gasto', `${feature.currentSharePct}%`, 'wants:share'),
+      evidenceItem('Promedio histórico', `${feature.baselineSharePct}%`, 'wants:baseline'),
+    ],
+    dataQuality: feature.dataQuality,
+    actions: [{ label: 'Ver deseos', question: '¿Cuánto llevo gastado en deseos este mes?' }],
+    validUntil: endOfMonth(snapshot.month),
+    dedupeKey: `wants_creep:${snapshot.month}`,
+  }
+}
+
+// ─── goal_pace ───────────────────────────────────────────────────────────────
+// Meta activa con fecha objetivo que viene atrasada (o encaminada → positivo).
+
+function ruleGoalPace(snapshot: FinancialSnapshot): InsightCandidate | null {
+  const pace = computeGoalPace(snapshot)
+  const currency = snapshot.currency
+
+  const behind = pace.behind.find((goal) => goal.currency === currency) ?? pace.behind[0]
+  if (behind && behind.requiredMonthlyContribution !== null) {
+    const planned = behind.plannedMonthlyContribution
+    const plannedLine =
+      planned !== null && planned > 0
+        ? ` Tu aporte planificado es ${formatAmount(planned, behind.currency)}/mes.`
+        : ''
+    return {
+      id: `goal_pace:${behind.id}:${snapshot.month}`,
+      kind: 'goal_pace',
+      severity: 'watch',
+      priority:
+        SEVERITY_WEIGHT.watch +
+        clamp(behind.monthsRemaining !== null ? 12 - behind.monthsRemaining : 0, 0, 12),
+      title: `La meta ${behind.name} viene atrasada`,
+      short: `${behind.name}: falta ${formatAmount(behind.remainingAmount, behind.currency)} (${behind.progressPct}% logrado)`,
+      message: `Para llegar a ${formatAmount(behind.targetAmount, behind.currency)} en ${formatShortDate(behind.targetDate ?? '')} necesitás aportar ${formatAmount(behind.requiredMonthlyContribution, behind.currency)}/mes.${plannedLine}`,
+      evidence: [
+        moneyEvidence('Falta', behind.remainingAmount, behind.currency, `goal:${behind.id}`),
+        moneyEvidence(
+          'Necesitás por mes',
+          behind.requiredMonthlyContribution,
+          behind.currency,
+          `goal:${behind.id}`,
+        ),
+        evidenceItem('Avance', `${behind.progressPct}%`, `goal:${behind.id}`),
+      ],
+      dataQuality: 'ok',
+      actions: [{ label: 'Ver metas', question: '¿Cómo vienen mis metas?' }],
+      validUntil: endOfMonth(snapshot.month),
+      dedupeKey: `goal_pace:${behind.id}`,
+    }
+  }
+
+  const onTrack = pace.onTrack[0]
+  if (onTrack) {
+    return {
+      id: `goal_pace:${onTrack.id}:${snapshot.month}`,
+      kind: 'goal_pace',
+      severity: 'positive',
+      priority: SEVERITY_WEIGHT.positive - 40,
+      title: `La meta ${onTrack.name} viene encaminada`,
+      short: `${onTrack.name}: ${onTrack.progressPct}% logrado`,
+      message: `Llevás ${formatAmount(onTrack.currentAmount, onTrack.currency)} de ${formatAmount(onTrack.targetAmount, onTrack.currency)} (${onTrack.progressPct}%)${onTrack.targetDate ? ` y venís a ritmo para llegar en ${formatShortDate(onTrack.targetDate)}` : ''}.`,
+      evidence: [
+        moneyEvidence('Ahorrado', onTrack.currentAmount, onTrack.currency, `goal:${onTrack.id}`),
+        evidenceItem('Avance', `${onTrack.progressPct}%`, `goal:${onTrack.id}`),
+      ],
+      dataQuality: 'ok',
+      actions: [{ label: 'Ver metas', question: '¿Cómo vienen mis metas?' }],
+      validUntil: endOfMonth(snapshot.month),
+      dedupeKey: `goal_pace:${onTrack.id}`,
+    }
+  }
+
+  return null
+}
+
+// ─── income_missing ──────────────────────────────────────────────────────────
+// Ingreso recurrente que ya debería haberse acreditado y no está registrado.
+
+function ruleIncomeMissing(snapshot: FinancialSnapshot): InsightCandidate | null {
+  const [missing] = computeMissingIncomes(snapshot)
+  if (!missing) return null
+
+  const daysLate = snapshot.dayOfMonth - missing.dayOfMonth
+
+  return {
+    id: `income_missing:${missing.id}:${snapshot.month}`,
+    kind: 'income_missing',
+    severity: 'watch',
+    priority: SEVERITY_WEIGHT.watch + clamp(daysLate * 2, 0, 20),
+    title: `No veo tu ingreso "${missing.description}" este mes`,
+    short: `${missing.description} (~${formatAmount(missing.amount, missing.currency)}) suele llegar el día ${missing.dayOfMonth}`,
+    message: `Tu ingreso recurrente "${missing.description}" (~${formatAmount(missing.amount, missing.currency)}) suele acreditarse el día ${missing.dayOfMonth} y todavía no está registrado. Si ya lo cobraste, registralo para que el disponible sea real.`,
+    evidence: [
+      moneyEvidence('Monto habitual', missing.amount, missing.currency, `recurring_income:${missing.id}`),
+      evidenceItem('Día habitual', `día ${missing.dayOfMonth}`, `recurring_income:${missing.id}`),
+      evidenceItem('Días de atraso', `${daysLate}`, 'calendar'),
+    ],
+    dataQuality: 'ok',
+    actions: [{ label: 'Registrar ingreso', href: '/' }],
+    validUntil: endOfMonth(snapshot.month),
+    dedupeKey: `income_missing:${missing.id}:${snapshot.month}`,
+  }
+}
+
+// ─── subscription_load ───────────────────────────────────────────────────────
+// El total de suscripciones activas pesa demasiado sobre el ingreso.
+
+function ruleSubscriptionLoad(snapshot: FinancialSnapshot): InsightCandidate | null {
+  const currency = snapshot.currency
+  const subscriptions = snapshot.subscriptions.filter((sub) => sub.currency === currency)
+  if (subscriptions.length === 0) return null
+
+  const income = computeMonthlyIncomeReference(snapshot)
+  if (!income.amount || income.amount <= 0) return null
+
+  const total = subscriptions.reduce((sum, sub) => sum + sub.amount, 0)
+  const sharePct = Math.round((total / income.amount) * 100)
+  if (sharePct < 12) return null
+
+  const severity: InsightSeverity = sharePct >= 20 ? 'watch' : 'info'
+
+  return {
+    id: `subscription_load:${snapshot.month}`,
+    kind: 'subscription_load',
+    severity,
+    priority: SEVERITY_WEIGHT[severity] + clamp(sharePct - 12, 0, 20),
+    title: `Las suscripciones se llevan el ${sharePct}% de tu ingreso`,
+    short: `${subscriptions.length} suscripciones por ${formatAmount(total, currency)}/mes (${sharePct}%)`,
+    message: `Tenés ${subscriptions.length} suscripciones activas que suman ${formatAmount(total, currency)} por mes, el ${sharePct}% de tu ingreso de referencia (${formatAmount(income.amount, currency)}).`,
+    evidence: [
+      moneyEvidence('Suscripciones/mes', total, currency, 'subscriptions:total'),
+      evidenceItem('Peso sobre ingreso', `${sharePct}%`, 'subscriptions:share'),
+      evidenceItem('Cantidad', String(subscriptions.length), 'subscriptions:count'),
+    ],
+    dataQuality: 'ok',
+    actions: [{ label: 'Ver suscripciones', question: '¿Qué suscripciones estoy pagando?' }],
+    validUntil: endOfMonth(snapshot.month),
+    dedupeKey: `subscription_load:${snapshot.month}`,
+  }
+}
+
 // ─── Orquestación ────────────────────────────────────────────────────────────
 
 export function buildInsightCandidates(snapshot: FinancialSnapshot): InsightCandidate[] {
@@ -257,6 +478,11 @@ export function buildInsightCandidates(snapshot: FinancialSnapshot): InsightCand
     ruleLiquidityWatch(snapshot),
     ruleSameDaySpendDelta(snapshot),
     ruleRecentUnusualMovement(snapshot),
+    ruleInstallmentLoad(snapshot),
+    ruleWantsCreep(snapshot),
+    ruleGoalPace(snapshot),
+    ruleIncomeMissing(snapshot),
+    ruleSubscriptionLoad(snapshot),
   ]
   for (const candidate of singles) {
     if (candidate) candidates.push(candidate)

--- a/lib/intelligence/insight-rules.ts
+++ b/lib/intelligence/insight-rules.ts
@@ -177,7 +177,7 @@ function ruleUpcomingCardDue(snapshot: FinancialSnapshot): InsightCandidate[] {
 }
 
 // ─── liquidity_watch ─────────────────────────────────────────────────────────
-// Disponible Real bajo frente a compromisos fechados de los próximos 14 días.
+// Saldo Vivo (caja) bajo frente a compromisos fechados de los próximos 14 días.
 
 function ruleLiquidityWatch(snapshot: FinancialSnapshot): InsightCandidate | null {
   const liquidity = computeLiquidity(snapshot, 14)
@@ -192,11 +192,11 @@ function ruleLiquidityWatch(snapshot: FinancialSnapshot): InsightCandidate | nul
     kind: 'liquidity_watch',
     severity: 'risk',
     priority: SEVERITY_WEIGHT.risk + 40,
-    title: 'El disponible no cubre lo que viene',
-    short: `Disponible ${formatAmount(liquidity.disponible, currency)} vs ${formatAmount(liquidity.upcomingTotal, currency)} comprometidos`,
-    message: `Tenés ${formatAmount(liquidity.disponible, currency)} disponibles y ${formatAmount(liquidity.upcomingTotal, currency)} comprometidos en los próximos 14 días (lo más pesado: ${topItem.label}, ${formatAmount(topItem.amount, currency)}).`,
+    title: 'El saldo no cubre lo que viene',
+    short: `Saldo Vivo ${formatAmount(liquidity.saldo, currency)} vs ${formatAmount(liquidity.upcomingTotal, currency)} comprometidos`,
+    message: `Tenés ${formatAmount(liquidity.saldo, currency)} en Saldo Vivo y ${formatAmount(liquidity.upcomingTotal, currency)} que vencen en los próximos 14 días (lo más pesado: ${topItem.label}, ${formatAmount(topItem.amount, currency)}).`,
     evidence: [
-      moneyEvidence('Disponible Real', liquidity.disponible, currency, 'dashboard:disponible_real'),
+      moneyEvidence('Saldo Vivo', liquidity.saldo, currency, 'dashboard:saldo_vivo'),
       moneyEvidence('Comprometido 14 días', liquidity.upcomingTotal, currency, 'commitments:14d'),
       moneyEvidence(topItem.label, topItem.amount, currency, `commitments:${topItem.source}`),
     ],

--- a/lib/intelligence/projection.ts
+++ b/lib/intelligence/projection.ts
@@ -85,7 +85,7 @@ export function computeInstallmentHorizon(snapshot: FinancialSnapshot): Installm
 
 export type SafeToSpendFeature = {
   disponible: number
-  /** Compromisos fechados que faltan pagar dentro del mes (resúmenes + débitos). */
+  /** Salidas fechadas del mes que Disponible Real todavía no descuenta (débitos). */
   committedRemaining: number
   /** Plata ya comprometida en metas (se respeta, no se toca). */
   goalCommitted: number
@@ -103,23 +103,11 @@ export function computeSafeToSpend(snapshot: FinancialSnapshot): SafeToSpendFeat
   const daysLeft = Math.max(1, snapshot.daysInMonth - snapshot.dayOfMonth + 1)
   const monthEnd = endOfMonth(snapshot.month)
 
+  // Disponible Real ya descuenta TODA la deuda de tarjeta (resúmenes
+  // pendientes + ciclo en curso) vía availableBreakdown = saldo − gastosTarjeta.
+  // Restar acá los resúmenes sería un doble descuento; solo se restan las
+  // salidas fechadas que el disponible todavía no absorbió: débitos automáticos.
   const items: UpcomingCommitmentItem[] = []
-
-  for (const card of snapshot.cards) {
-    for (const statement of card.pendingStatements) {
-      if (statement.amount <= 0) continue
-      // Un resumen vencido sigue debido; uno que vence después de fin de mes
-      // no presiona el ritmo de este mes.
-      if (statement.status !== 'vencido' && statement.dueDate > monthEnd) continue
-      items.push({
-        label: `Resumen ${card.cardName}`,
-        amount: statement.amount,
-        date: statement.dueDate,
-        daysUntil: diffDays(snapshot.referenceDate, statement.dueDate),
-        source: 'card',
-      })
-    }
-  }
 
   for (const subscription of snapshot.subscriptions) {
     if (subscription.paymentMethod !== 'DEBIT') continue

--- a/lib/intelligence/projection.ts
+++ b/lib/intelligence/projection.ts
@@ -1,0 +1,229 @@
+import { diffDays, endOfMonth } from './evidence'
+import { nextSubscriptionDate, type UpcomingCommitmentItem } from './features'
+import type { DataQuality, FinancialSnapshot } from './types'
+
+// ─── Horizonte de cuotas comprometidas ───────────────────────────────────────
+
+export type InstallmentMonthLoad = {
+  month: string
+  amount: number
+  count: number
+  /** % del ingreso mensual de referencia que ya está comprometido en cuotas. */
+  incomeSharePct: number | null
+}
+
+export type InstallmentHorizonFeature = {
+  months: InstallmentMonthLoad[]
+  peak: InstallmentMonthLoad | null
+  monthlyIncomeReference: number | null
+  incomeReferenceSource: 'recurring' | 'history' | null
+  dataQuality: DataQuality
+}
+
+/**
+ * Ingreso mensual de referencia en moneda base: la suma de ingresos
+ * recurrentes activos, o —si no hay configurados— el promedio de los meses
+ * cerrados con ingreso registrado.
+ */
+export function computeMonthlyIncomeReference(snapshot: FinancialSnapshot): {
+  amount: number | null
+  source: 'recurring' | 'history' | null
+} {
+  const currency = snapshot.currency
+  const recurringTotal = snapshot.recurringIncomes
+    .filter((income) => income.currency === currency)
+    .reduce((sum, income) => sum + income.amount, 0)
+  if (recurringTotal > 0) return { amount: recurringTotal, source: 'recurring' }
+
+  const closedIncomes = snapshot.monthAggregates
+    .filter((aggregate) => aggregate.month < snapshot.month && aggregate.income[currency] > 0)
+    .map((aggregate) => aggregate.income[currency])
+  if (closedIncomes.length === 0) return { amount: null, source: null }
+
+  return {
+    amount: Math.round(closedIncomes.reduce((sum, amount) => sum + amount, 0) / closedIncomes.length),
+    source: 'history',
+  }
+}
+
+/**
+ * Cuánto de cada mes futuro ya está comprometido en cuotas (moneda base).
+ * Las cuotas son gastos con fecha futura ya materializados: esto no estima,
+ * suma compromisos reales.
+ */
+export function computeInstallmentHorizon(snapshot: FinancialSnapshot): InstallmentHorizonFeature {
+  const currency = snapshot.currency
+  const income = computeMonthlyIncomeReference(snapshot)
+
+  const months: InstallmentMonthLoad[] = snapshot.futureInstallments
+    .map((entry) => ({
+      month: entry.month,
+      amount: Math.round(entry.amount[currency]),
+      count: entry.count,
+      incomeSharePct:
+        income.amount && income.amount > 0
+          ? Math.round((entry.amount[currency] / income.amount) * 100)
+          : null,
+    }))
+    .filter((entry) => entry.amount > 0)
+
+  const peak = months.reduce<InstallmentMonthLoad | null>(
+    (max, entry) => (max === null || entry.amount > max.amount ? entry : max),
+    null,
+  )
+
+  return {
+    months,
+    peak,
+    monthlyIncomeReference: income.amount,
+    incomeReferenceSource: income.source,
+    dataQuality: months.length === 0 ? 'insufficient' : income.amount ? 'ok' : 'partial',
+  }
+}
+
+// ─── Safe-to-spend: ritmo diario sugerido hasta fin de mes ───────────────────
+
+export type SafeToSpendFeature = {
+  disponible: number
+  /** Compromisos fechados que faltan pagar dentro del mes (resúmenes + débitos). */
+  committedRemaining: number
+  /** Plata ya comprometida en metas (se respeta, no se toca). */
+  goalCommitted: number
+  spendable: number
+  daysLeft: number
+  dailyAmount: number | null
+  items: UpcomingCommitmentItem[]
+  dataQuality: DataQuality
+}
+
+export function computeSafeToSpend(snapshot: FinancialSnapshot): SafeToSpendFeature {
+  const currency = snapshot.currency
+  const disponible = snapshot.disponibleReal[currency]
+  const goalCommitted = snapshot.goals.committed[currency]
+  const daysLeft = Math.max(1, snapshot.daysInMonth - snapshot.dayOfMonth + 1)
+  const monthEnd = endOfMonth(snapshot.month)
+
+  const items: UpcomingCommitmentItem[] = []
+
+  for (const card of snapshot.cards) {
+    for (const statement of card.pendingStatements) {
+      if (statement.amount <= 0) continue
+      // Un resumen vencido sigue debido; uno que vence después de fin de mes
+      // no presiona el ritmo de este mes.
+      if (statement.status !== 'vencido' && statement.dueDate > monthEnd) continue
+      items.push({
+        label: `Resumen ${card.cardName}`,
+        amount: statement.amount,
+        date: statement.dueDate,
+        daysUntil: diffDays(snapshot.referenceDate, statement.dueDate),
+        source: 'card',
+      })
+    }
+  }
+
+  for (const subscription of snapshot.subscriptions) {
+    if (subscription.paymentMethod !== 'DEBIT') continue
+    if (subscription.currency !== currency) continue
+    const date = nextSubscriptionDate(snapshot, subscription.dayOfMonth)
+    if (date > monthEnd) continue
+    items.push({
+      label: subscription.description,
+      amount: subscription.amount,
+      date,
+      daysUntil: diffDays(snapshot.referenceDate, date),
+      source: 'subscription',
+    })
+  }
+
+  items.sort((a, b) => a.date.localeCompare(b.date))
+  const committedRemaining = items.reduce((sum, item) => sum + item.amount, 0)
+  const spendable = disponible - goalCommitted - committedRemaining
+
+  return {
+    disponible,
+    committedRemaining,
+    goalCommitted,
+    spendable,
+    daysLeft,
+    dailyAmount: spendable > 0 ? Math.floor(spendable / daysLeft) : null,
+    items,
+    // Solo tiene sentido para el mes en curso.
+    dataQuality: snapshot.comparisonDay === null ? 'insufficient' : 'ok',
+  }
+}
+
+// ─── Simulación de compra ("¿me alcanza?") ───────────────────────────────────
+
+export type SimulatedInstallmentMonth = {
+  month: string
+  newTotal: number
+  incomeSharePct: number | null
+}
+
+export type PurchaseSimulation = {
+  amount: number
+  installments: number | null
+  /** Compra al contado: qué queda después. */
+  upfront: {
+    spendableAfter: number
+    dailyAfter: number | null
+    fits: boolean
+  } | null
+  /** Compra en cuotas: carga mensual nueva y meses futuros con la cuota sumada. */
+  installmentPlan: {
+    monthlyAmount: number
+    monthsAffected: SimulatedInstallmentMonth[]
+  } | null
+}
+
+/**
+ * Simula el impacto de una compra sobre el mes (contado) o los meses futuros
+ * (cuotas). Todo determinístico: el LLM solo redacta el veredicto.
+ */
+export function simulatePurchase(
+  snapshot: FinancialSnapshot,
+  params: { amount: number; installments: number | null },
+): PurchaseSimulation {
+  const safe = computeSafeToSpend(snapshot)
+  const horizon = computeInstallmentHorizon(snapshot)
+  const income = computeMonthlyIncomeReference(snapshot)
+
+  if (params.installments && params.installments > 1) {
+    const monthlyAmount = Math.round(params.amount / params.installments)
+    const monthsAffected: SimulatedInstallmentMonth[] = []
+
+    const horizonByMonth = new Map(horizon.months.map((entry) => [entry.month, entry.amount]))
+    let cursor = snapshot.month
+    for (let index = 0; index < Math.min(params.installments, 6); index += 1) {
+      const [year, monthNumber] = cursor.split('-').map(Number)
+      const next = new Date(Date.UTC(year, monthNumber, 1))
+      cursor = `${next.getUTCFullYear()}-${String(next.getUTCMonth() + 1).padStart(2, '0')}`
+      const newTotal = (horizonByMonth.get(cursor) ?? 0) + monthlyAmount
+      monthsAffected.push({
+        month: cursor,
+        newTotal,
+        incomeSharePct:
+          income.amount && income.amount > 0 ? Math.round((newTotal / income.amount) * 100) : null,
+      })
+    }
+
+    return {
+      amount: params.amount,
+      installments: params.installments,
+      upfront: null,
+      installmentPlan: { monthlyAmount, monthsAffected },
+    }
+  }
+
+  const spendableAfter = safe.spendable - params.amount
+  return {
+    amount: params.amount,
+    installments: null,
+    upfront: {
+      spendableAfter,
+      dailyAfter: spendableAfter > 0 ? Math.floor(spendableAfter / safe.daysLeft) : null,
+      fits: spendableAfter >= 0,
+    },
+    installmentPlan: null,
+  }
+}

--- a/lib/intelligence/snapshot.ts
+++ b/lib/intelligence/snapshot.ts
@@ -18,10 +18,13 @@ import type {
   CategoryAggregate,
   Currency,
   FinancialSnapshot,
+  FutureInstallmentMonth,
   MonthAggregate,
   SnapshotAccountBalance,
   SnapshotCardCommitment,
+  SnapshotGoal,
   SnapshotMovement,
+  SnapshotRecurringIncome,
   SnapshotSubscription,
 } from './types'
 
@@ -40,7 +43,10 @@ export type SnapshotExpenseRow = Pick<
   | 'date'
   | 'installment_number'
   | 'installment_total'
->
+> & {
+  /** Opcional: la columna puede no existir en bases sin la migración de flags. */
+  is_extraordinary?: boolean | null
+}
 
 export type SnapshotIncomeRow = Pick<
   IncomeEntry,
@@ -63,6 +69,10 @@ export type SnapshotInputs = {
   cards: SnapshotCardCommitment[]
   subscriptions: SnapshotSubscription[]
   goals: { count: number; committed: Record<Currency, number> }
+  goalsDetail?: SnapshotGoal[]
+  recurringIncomes?: SnapshotRecurringIncome[]
+  /** Gastos con fecha futura (cuotas ya materializadas más allá del mes). */
+  futureExpenses?: SnapshotExpenseRow[]
   yieldAccumulated: number
   expenses: SnapshotExpenseRow[]
   incomeEntries: SnapshotIncomeRow[]
@@ -79,6 +89,34 @@ function installmentLabel(expense: SnapshotExpenseRow): string | null {
     return `${expense.installment_number}/${expense.installment_total}`
   }
   return null
+}
+
+/** Horizonte de meses futuros que se proyecta para cuotas comprometidas. */
+export const FUTURE_INSTALLMENT_MONTHS = 6
+
+function buildFutureInstallments(params: {
+  futureExpenses: SnapshotExpenseRow[]
+  month: string
+}): FutureInstallmentMonth[] {
+  const { futureExpenses, month } = params
+  const horizonEnd = addMonths(month, FUTURE_INSTALLMENT_MONTHS)
+  const byMonth = new Map<string, FutureInstallmentMonth>()
+
+  for (const expense of futureExpenses) {
+    if (!expense.installment_number || !expense.installment_total) continue
+    const expenseMonth = expense.date.substring(0, 7)
+    if (expenseMonth <= month || expenseMonth > horizonEnd) continue
+    const entry = byMonth.get(expenseMonth) ?? {
+      month: expenseMonth,
+      amount: emptyCurrencyTotals(),
+      count: 0,
+    }
+    entry.amount[expense.currency] += expense.amount
+    entry.count += 1
+    byMonth.set(expenseMonth, entry)
+  }
+
+  return Array.from(byMonth.values()).sort((a, b) => a.month.localeCompare(b.month))
 }
 
 function buildMonthAggregates(params: {
@@ -98,6 +136,8 @@ function buildMonthAggregates(params: {
       perceivedSpend: emptyCurrencyTotals(),
       accruedSpend: emptyCurrencyTotals(),
       cardPayments: emptyCurrencyTotals(),
+      wantsSpend: emptyCurrencyTotals(),
+      extraordinarySpend: emptyCurrencyTotals(),
       categories: [],
       categoryMap: new Map(),
     })
@@ -123,12 +163,18 @@ function buildMonthAggregates(params: {
     aggregate.income[income.currency] += income.amount
   }
 
+  const addFlagged = (aggregate: MonthAggregate, expense: SnapshotExpenseRow) => {
+    if (expense.is_want) aggregate.wantsSpend[expense.currency] += expense.amount
+    if (expense.is_extraordinary) aggregate.extraordinarySpend[expense.currency] += expense.amount
+  }
+
   for (const expense of expenses) {
     const aggregate = aggregateMap.get(expense.date.substring(0, 7))
     if (!aggregate) continue
     if (isPerceivedExpense(expense)) {
       aggregate.perceivedSpend[expense.currency] += expense.amount
       addCategory(aggregate, expense.category, expense.amount, expense.currency)
+      addFlagged(aggregate, expense)
       continue
     }
     if (isApplicableCardPayment(expense)) {
@@ -139,6 +185,7 @@ function buildMonthAggregates(params: {
     if (isCreditAccruedExpense(expense)) {
       aggregate.accruedSpend[expense.currency] += expense.amount
       addCategory(aggregate, expense.category, expense.amount, expense.currency)
+      addFlagged(aggregate, expense)
     }
   }
 
@@ -163,6 +210,7 @@ function buildMovements(params: {
     currency: expense.currency,
     paymentMethod: expense.payment_method,
     isWant: expense.is_want,
+    isExtraordinary: expense.is_extraordinary ?? null,
     isCardPayment: isCardPayment(expense),
     installmentLabel: installmentLabel(expense),
   }))
@@ -177,6 +225,7 @@ function buildMovements(params: {
     currency: income.currency,
     paymentMethod: null,
     isWant: null,
+    isExtraordinary: null,
     isCardPayment: false,
     installmentLabel: null,
   }))
@@ -191,6 +240,7 @@ function buildMovements(params: {
     currency: transfer.currency_to,
     paymentMethod: null,
     isWant: null,
+    isExtraordinary: null,
     isCardPayment: false,
     installmentLabel: null,
   }))
@@ -266,11 +316,65 @@ export function assembleFinancialSnapshot(inputs: SnapshotInputs): FinancialSnap
     cards: inputs.cards,
     subscriptions: inputs.subscriptions,
     goals: inputs.goals,
+    goalsDetail: inputs.goalsDetail ?? [],
+    recurringIncomes: inputs.recurringIncomes ?? [],
+    futureInstallments: buildFutureInstallments({
+      futureExpenses: inputs.futureExpenses ?? [],
+      month,
+    }),
     yieldAccumulated: inputs.yieldAccumulated,
     movements: buildMovements({ expenses, incomeEntries, transfers }),
     monthAggregates: buildMonthAggregates({ expenses, incomeEntries, historyStartMonth, month }),
     hasOtherCurrencyMovements,
   }
+}
+
+const EXPENSE_BASE_COLUMNS =
+  'id, amount, currency, category, description, is_want, payment_method, is_legacy_card_payment, date, installment_number, installment_total'
+
+function isMissingExtraordinaryColumnError(error: unknown): boolean {
+  const candidate = error as { message?: string | null; details?: string | null; hint?: string | null }
+  return `${candidate?.message ?? ''} ${candidate?.details ?? ''} ${candidate?.hint ?? ''}`
+    .toLowerCase()
+    .includes('is_extraordinary')
+}
+
+/**
+ * Query de gastos con `is_extraordinary` cuando la columna existe; si la base
+ * no tiene la migración de flags, reintenta sin ella (mismo fallback que los
+ * writes de /api/expenses).
+ */
+async function fetchExpenseRows(options: {
+  supabase: SupabaseClient
+  userId: string
+  fromDate: string
+  toDate: string
+  onlyInstallments?: boolean
+  limit: number
+}): Promise<SnapshotExpenseRow[]> {
+  const run = (withExtraordinary: boolean) => {
+    let query = options.supabase
+      .from('expenses')
+      .select(withExtraordinary ? `${EXPENSE_BASE_COLUMNS}, is_extraordinary` : EXPENSE_BASE_COLUMNS)
+      .eq('user_id', options.userId)
+      .gte('date', options.fromDate)
+      .lt('date', options.toDate)
+    if (options.onlyInstallments) {
+      query = query.not('installment_group_id', 'is', null)
+    }
+    return query
+      .order('date', { ascending: false })
+      .order('created_at', { ascending: false })
+      .limit(options.limit)
+  }
+
+  const first = await run(true)
+  if (!first.error) return (first.data ?? []) as unknown as SnapshotExpenseRow[]
+  if (!isMissingExtraordinaryColumnError(first.error)) throw first.error
+
+  const fallback = await run(false)
+  if (fallback.error) throw fallback.error
+  return (fallback.data ?? []) as unknown as SnapshotExpenseRow[]
 }
 
 /**
@@ -287,6 +391,7 @@ export async function loadFinancialSnapshot(params: {
   const today = todayAR()
   const historyStartDate = `${addMonths(month, -5)}-01`
   const nextMonthDate = `${addMonths(month, 1)}-01`
+  const futureHorizonDate = `${addMonths(month, FUTURE_INSTALLMENT_MONTHS + 1)}-01`
 
   const { data: config } = await supabase
     .from('user_config')
@@ -296,21 +401,25 @@ export async function loadFinancialSnapshot(params: {
 
   const currency = (config?.default_currency ?? 'ARS') as Currency
 
-  const [dashboard, budget, expensesResult, incomeResult, transfersResult, oldestExpenseResult] =
+  const [dashboard, budget, expenses, futureExpenses, incomeResult, transfersResult, oldestExpenseResult] =
     await Promise.all([
       readDashboardData({ supabase, userId, selectedMonth: month, viewCurrency: currency }),
       getBudgetSnapshot({ supabase, userId, month, currency }),
-      supabase
-        .from('expenses')
-        .select(
-          'id, amount, currency, category, description, is_want, payment_method, is_legacy_card_payment, date, installment_number, installment_total',
-        )
-        .eq('user_id', userId)
-        .gte('date', historyStartDate)
-        .lt('date', nextMonthDate)
-        .order('date', { ascending: false })
-        .order('created_at', { ascending: false })
-        .limit(500),
+      fetchExpenseRows({
+        supabase,
+        userId,
+        fromDate: historyStartDate,
+        toDate: nextMonthDate,
+        limit: 500,
+      }),
+      fetchExpenseRows({
+        supabase,
+        userId,
+        fromDate: nextMonthDate,
+        toDate: futureHorizonDate,
+        onlyInstallments: true,
+        limit: 400,
+      }),
       supabase
         .from('income_entries')
         .select('id, amount, currency, description, category, date')
@@ -336,7 +445,6 @@ export async function loadFinancialSnapshot(params: {
         .maybeSingle(),
     ])
 
-  if (expensesResult.error) throw expensesResult.error
   if (incomeResult.error) throw incomeResult.error
   if (transfersResult.error) throw transfersResult.error
   if (oldestExpenseResult.error) throw oldestExpenseResult.error
@@ -363,6 +471,32 @@ export async function loadFinancialSnapshot(params: {
     dayOfMonth: sub.day_of_month,
   }))
 
+  const goalsDetail: SnapshotGoal[] = dashboard.goals.map((goal) => ({
+    id: goal.id,
+    name: goal.name,
+    status: goal.status,
+    currency: goal.currency,
+    targetAmount: goal.targetAmount,
+    currentAmount: goal.currentAmount,
+    remainingAmount: goal.remainingAmount,
+    progressPct: goal.progressPct,
+    targetDate: goal.targetDate,
+    monthsRemaining: goal.monthsRemaining,
+    requiredMonthlyContribution: goal.requiredMonthlyContribution,
+    plannedMonthlyContribution: goal.plannedMonthlyContribution,
+    paceStatus: goal.paceStatus,
+  }))
+
+  const pendingRecurringIds = new Set(dashboard.recurringPending.map((income) => income.id))
+  const recurringIncomes: SnapshotRecurringIncome[] = dashboard.activeRecurring.map((income) => ({
+    id: income.id,
+    description: income.description || income.category,
+    amount: income.amount,
+    currency: income.currency as Currency,
+    dayOfMonth: income.day_of_month,
+    pendingThisMonth: pendingRecurringIds.has(income.id),
+  }))
+
   return assembleFinancialSnapshot({
     today,
     month,
@@ -378,8 +512,11 @@ export async function loadFinancialSnapshot(params: {
     cards,
     subscriptions,
     goals: { count: dashboard.goals.length, committed: dashboard.goalCommitmentsBreakdown },
+    goalsDetail,
+    recurringIncomes,
+    futureExpenses,
     yieldAccumulated: dashboard.dashboardData?.saldo_vivo?.rendimientos ?? 0,
-    expenses: (expensesResult.data ?? []) as SnapshotExpenseRow[],
+    expenses,
     incomeEntries: (incomeResult.data ?? []) as SnapshotIncomeRow[],
     transfers: (transfersResult.data ?? []) as SnapshotTransferRow[],
     earliestDataMonth: oldestExpenseResult.data?.date?.substring(0, 7) ?? null,

--- a/lib/intelligence/types.ts
+++ b/lib/intelligence/types.ts
@@ -25,6 +25,11 @@ export type InsightKind =
   | 'upcoming_card_due'
   | 'liquidity_watch'
   | 'recent_unusual_movement'
+  | 'installment_load'
+  | 'wants_creep'
+  | 'goal_pace'
+  | 'income_missing'
+  | 'subscription_load'
 
 export type InsightAction = {
   label: string
@@ -61,6 +66,7 @@ export type SnapshotMovement = {
   currency: Currency
   paymentMethod: 'CASH' | 'DEBIT' | 'TRANSFER' | 'CREDIT' | null
   isWant: boolean | null
+  isExtraordinary: boolean | null
   isCardPayment: boolean
   installmentLabel: string | null
 }
@@ -108,7 +114,46 @@ export type MonthAggregate = {
   perceivedSpend: Record<Currency, number>
   accruedSpend: Record<Currency, number>
   cardPayments: Record<Currency, number>
+  /** Gasto marcado como deseo (percibido + devengado, sin pagos de tarjeta). */
+  wantsSpend: Record<Currency, number>
+  /** Gasto marcado como extraordinario: se excluye de los baselines históricos. */
+  extraordinarySpend: Record<Currency, number>
   categories: CategoryAggregate[]
+}
+
+export type GoalPace = 'on_track' | 'behind' | 'no_date' | 'completed' | 'paused'
+
+export type SnapshotGoal = {
+  id: string
+  name: string
+  status: 'active' | 'paused' | 'completed' | 'archived'
+  currency: Currency
+  targetAmount: number
+  currentAmount: number
+  remainingAmount: number
+  progressPct: number
+  targetDate: string | null
+  monthsRemaining: number | null
+  requiredMonthlyContribution: number | null
+  plannedMonthlyContribution: number | null
+  paceStatus: GoalPace
+}
+
+export type SnapshotRecurringIncome = {
+  id: string
+  description: string
+  amount: number
+  currency: Currency
+  dayOfMonth: number
+  /** true si ya pasó su día de cobro este mes y no hay ingreso registrado. */
+  pendingThisMonth: boolean
+}
+
+/** Cuotas ya comprometidas para un mes futuro (gastos con fecha futura). */
+export type FutureInstallmentMonth = {
+  month: string
+  amount: Record<Currency, number>
+  count: number
 }
 
 /**
@@ -138,6 +183,9 @@ export type FinancialSnapshot = {
   cards: SnapshotCardCommitment[]
   subscriptions: SnapshotSubscription[]
   goals: { count: number; committed: Record<Currency, number> }
+  goalsDetail: SnapshotGoal[]
+  recurringIncomes: SnapshotRecurringIncome[]
+  futureInstallments: FutureInstallmentMonth[]
   yieldAccumulated: number
 
   movements: SnapshotMovement[]


### PR DESCRIPTION
- is_extraordinary en movimientos y agregados (con fallback si falta la columna)
- wantsSpend/extraordinarySpend por mes para baselines limpios
- goalsDetail con métricas completas (pace, required, target date)
- ingresos recurrentes activos + pendientes del mes
- futureInstallments: cuotas ya materializadas de los próximos 6 meses

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P9xNwpbQwRGZnMyP3Lq6aU