### PR TITLE
fix(home): preserve ambient intelligence copy

### DIFF
--- a/components/dashboard/CommitmentsSummary.tsx
+++ b/components/dashboard/CommitmentsSummary.tsx
@@ -81,7 +81,7 @@ export function CommitmentsSummary({
                 <div className="min-w-0">
                   <p className="type-body text-text-secondary">Compromisos en tarjetas</p>
                   <p
-                    className={`mt-1 truncate type-meta ${
+                    className={`mt-1 break-words leading-tight type-meta ${
                       ambient ? AMBIENT_FOOTER_COLOR[ambient.status] : 'text-text-dim'
                     }`}
                   >

--- a/components/intelligence/HomeAmbientLine.tsx
+++ b/components/intelligence/HomeAmbientLine.tsx
@@ -43,7 +43,7 @@ export function HomeAmbientLine({
           className={`${compact ? 'h-1 w-1' : 'h-1.5 w-1.5'} shrink-0 rounded-full ${dot}`}
         />
       )}
-      <span className={`truncate ${textSize} font-medium ${STATUS_TEXT[modifier.status]}`}>
+      <span className={`break-words ${textSize} font-medium leading-tight ${STATUS_TEXT[modifier.status]}`}>
         {modifier.label}
       </span>
       {interactive && <CaretRight size={12} weight="regular" className="shrink-0 text-text-tertiary" />}


### PR DESCRIPTION
## Resumen
Corrige los dos truncados visibles en Home que no pertenecían al Action Slot:
- Disponible Real (`HomeAmbientLine`)
- footer ambiental de Compromisos

Ambas líneas ahora pueden envolver texto y conservar la frase completa, en lugar de mostrar `…`.

## Verificación
- `npx eslint components/intelligence/HomeAmbientLine.tsx components/dashboard/CommitmentsSummary.tsx`
- `npx tsc --noEmit`
- `git diff --check`

Todos pasan.