### PR TITLE
feat(web): compact movimientos workspace

### DIFF
--- a/app/(web)/web/page.tsx
+++ b/app/(web)/web/page.tsx
@@ -1,23 +1,28 @@
 import { ReactQueryProvider } from '@/components/providers/ReactQueryProvider'
 import { WebDashboardRoute } from '@/components/web/dashboard/WebDashboardRoute'
 import { loadDashboardPageData } from '@/lib/server/load-dashboard-page-data'
+import { parseWebNavView } from '@/lib/web-panel/navigation'
 
 export default async function WebPage({
   searchParams,
 }: {
-  searchParams: Promise<{ month?: string; currency?: string }>
+  searchParams: Promise<{ month?: string; currency?: string; view?: string }>
 }) {
+  const { view } = await searchParams
+  const initialView = parseWebNavView(view)
   const { selectedMonth, viewCurrency, userEmail, initialData, initialQuote } =
     await loadDashboardPageData({ searchParams })
 
   return (
     <ReactQueryProvider>
       <WebDashboardRoute
+        key={`${selectedMonth}:${viewCurrency}:${initialView}`}
         selectedMonth={selectedMonth}
         viewCurrency={viewCurrency}
         userEmail={userEmail}
         initialData={initialData}
         initialQuote={initialQuote}
+        initialView={initialView}
       />
     </ReactQueryProvider>
   )

--- a/components/dashboard/HomePlusButton.tsx
+++ b/components/dashboard/HomePlusButton.tsx
@@ -18,11 +18,12 @@ interface Props {
   cards: Card[]
   month: string
   onBlue?: boolean
+  label?: string
 }
 
 type Sheet = null | 'action' | 'income' | 'subscription' | 'cuotas' | 'transfer' | 'pago_tarjeta' | 'instrumento'
 
-export function HomePlusButton({ accounts, currency, cards, month, onBlue = false }: Props) {
+export function HomePlusButton({ accounts, currency, cards, onBlue = false, label }: Props) {
   const [sheet, setSheet] = useState<Sheet>(null)
   const activeCards = cards.filter((card) => !card.archived)
 
@@ -32,13 +33,15 @@ export function HomePlusButton({ accounts, currency, cards, month, onBlue = fals
         onClick={() => setSheet('action')}
         aria-label="Agregar movimiento"
         className={[
-          'flex h-9 w-9 items-center justify-center rounded-full transition-colors',
+          'flex items-center justify-center rounded-full transition-colors',
+          label ? 'h-9 gap-2 px-4 text-[13px] font-semibold' : 'h-9 w-9',
           onBlue
             ? 'header-glass hover:opacity-80 active:opacity-60'
-            : 'bg-primary hover:brightness-105 active:scale-95',
+            : 'bg-primary text-white hover:brightness-105 active:scale-95',
         ].join(' ')}
       >
-        <Plus weight="bold" size={18} className="text-white" />
+        <Plus weight="bold" size={label ? 15 : 18} className="text-white" />
+        {label && <span>{label}</span>}
       </button>
 
       {sheet === 'action' && (

--- a/components/dashboard/desktop/DesktopDashboardShell.tsx
+++ b/components/dashboard/desktop/DesktopDashboardShell.tsx
@@ -17,13 +17,12 @@ import { DesktopAttentionPanel } from './DesktopAttentionPanel'
 import { DesktopUpcomingTimeline } from './DesktopUpcomingTimeline'
 import { DesktopCommitmentsPanel } from './DesktopCommitmentsPanel'
 import { DesktopSecondarySummary } from './DesktopSecondarySummary'
+import { WebMovimientosWorkspace } from './WebMovimientosWorkspace'
 import {
   AnalisisView,
   CompromisosView,
-  CuentasView,
   FugaView,
   InstrumentosView,
-  MovimientosView,
   TarjetasView,
 } from './desktop-views'
 import {
@@ -316,9 +315,15 @@ export function DesktopDashboardShell({
           ) : activeNav === 'metas' ? (
             <MetasPage goals={data.goals} money={money} />
           ) : activeNav === 'movimientos' ? (
-            <MovimientosView {...viewProps} />
-          ) : activeNav === 'cuentas' ? (
-            <CuentasView {...viewProps} />
+            <WebMovimientosWorkspace
+              accounts={data.accounts}
+              cards={data.cards}
+              accountBalances={data.accountBalances}
+              selectedMonth={selectedMonth}
+              viewCurrency={viewCurrency}
+              hidden={hidden}
+              onOpenSettings={onOpenSettings}
+            />
           ) : activeNav === 'tarjetas' ? (
             <TarjetasView {...viewProps} />
           ) : activeNav === 'instrumentos' ? (

--- a/components/dashboard/desktop/WebMovimientosWorkspace.tsx
+++ b/components/dashboard/desktop/WebMovimientosWorkspace.tsx
@@ -1,0 +1,316 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  ArrowDownLeft,
+  ArrowLeft,
+  ArrowsLeftRight,
+  CaretRight,
+  CreditCard,
+  MagnifyingGlass,
+  TrendUp,
+  Wallet,
+} from '@phosphor-icons/react'
+import { HomePlusButton } from '@/components/dashboard/HomePlusButton'
+import { CategoryIcon, getCategoryColors } from '@/components/ui/CategoryIcon'
+import { fetchAllMovimientosForMonth, type ApiMovement } from './movimientos-data'
+import {
+  buildAccountActivityCounts,
+  buildWebMovementRows,
+  filterWebMovementRows,
+  groupWebMovementRows,
+  type WebMovementRow,
+  type WebMovementType,
+} from '@/lib/web-movimientos-model'
+import { formatAmount, todayAR } from '@/lib/format'
+import type { Account, Card } from '@/types/database'
+
+type AccountBalance = {
+  id: string
+  name: string
+  type: string
+  is_primary: boolean
+  saldo: number
+}
+
+type Props = {
+  accounts: Account[]
+  cards: Card[]
+  accountBalances: AccountBalance[]
+  selectedMonth: string
+  viewCurrency: 'ARS' | 'USD'
+  hidden: boolean
+  initialMovements?: ApiMovement[]
+  today?: string
+  onOpenSettings: () => void
+}
+
+const TYPE_OPTIONS: Array<{ value: WebMovementType; label: string }> = [
+  { value: 'all', label: 'Todos' },
+  { value: 'expense', label: 'Gastos' },
+  { value: 'income', label: 'Ingresos' },
+  { value: 'transfer', label: 'Transferencias' },
+  { value: 'yield', label: 'Rendimientos' },
+]
+
+function accountTypeLabel(type: string): string {
+  if (type === 'bank') return 'Banco'
+  if (type === 'digital') return 'Digital'
+  return 'Efectivo'
+}
+
+function signedAmountLabel(row: WebMovementRow, hidden: boolean): string {
+  if (hidden) return '••••••'
+  const prefix = row.tone === 'expense' ? '−' : row.tone === 'income' || row.tone === 'yield' ? '+' : ''
+  return `${prefix}${formatAmount(row.amount, row.currency)}`
+}
+
+function RowIcon({ row }: { row: WebMovementRow }) {
+  if (row.kind === 'expense') {
+    const colors = getCategoryColors(row.category ?? '')
+    return (
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[9px]" style={{ background: colors.colorSoft }}>
+        <CategoryIcon category={row.category ?? ''} size={16} />
+      </span>
+    )
+  }
+  const meta = {
+    income: { Icon: ArrowDownLeft, color: '#1A7A42', bg: 'rgba(26,122,66,0.10)' },
+    transfer: { Icon: ArrowsLeftRight, color: '#1B7E9E', bg: 'rgba(27,126,158,0.10)' },
+    yield: { Icon: TrendUp, color: '#1A7A42', bg: 'rgba(26,122,66,0.10)' },
+  }[row.kind]
+  const Icon = meta.Icon
+  return (
+    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[9px]" style={{ color: meta.color, background: meta.bg }}>
+      <Icon size={16} weight="bold" />
+    </span>
+  )
+}
+
+function MovementDetail({ row, hidden, onClose }: { row: WebMovementRow; hidden: boolean; onClose: () => void }) {
+  const source = row.source.data
+  const dateLabel = new Date(`${row.date}T12:00:00-03:00`).toLocaleDateString('es-AR', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+  })
+  const impactCopy =
+    row.kind === 'expense'
+      ? 'Descontado de la cuenta indicada y computado según su medio de pago.'
+      : row.kind === 'income'
+        ? 'Sumado al saldo de la cuenta y al ingreso registrado del período.'
+        : row.kind === 'transfer'
+          ? 'Movió fondos entre cuentas propias sin contarlo como ingreso ni gasto.'
+          : 'Sumado al saldo de la cuenta como rendimiento del instrumento.'
+
+  return (
+    <aside data-web-account-context="true" className="web-mov-context rounded-[14px] border border-primary/[0.09] bg-white p-5 shadow-[0_1px_4px_rgba(13,24,41,0.04)]">
+      <button type="button" onClick={onClose} className="mb-5 inline-flex items-center gap-1.5 text-[12px] font-semibold text-primary">
+        <ArrowLeft size={13} weight="bold" /> Volver a cuentas
+      </button>
+      <div className="mb-2 text-[10px] font-bold uppercase tracking-[0.09em] text-text-dim">{row.kind === 'expense' ? 'Gasto' : row.kind === 'income' ? 'Ingreso' : row.kind === 'transfer' ? 'Transferencia' : 'Rendimiento'}</div>
+      <h2 className="m-0 text-[20px] font-bold tracking-[-0.025em] text-text-primary">{row.title}</h2>
+      <div className={`mt-5 text-[28px] font-extrabold tabular-nums tracking-[-0.04em] ${row.tone === 'income' || row.tone === 'yield' ? 'text-success' : 'text-text-primary'}`}>
+        {signedAmountLabel(row, hidden)}
+      </div>
+      <div className="mt-1 capitalize text-[12px] text-text-dim">{dateLabel}</div>
+
+      <dl className="mt-6 border-y border-primary/[0.08] py-2 text-[12px]">
+        {row.category && (
+          <div className="flex justify-between gap-4 py-2.5"><dt className="text-text-dim">Categoría</dt><dd className="m-0 text-right font-semibold text-text-primary">{row.category}</dd></div>
+        )}
+        <div className="flex justify-between gap-4 py-2.5"><dt className="text-text-dim">Origen</dt><dd className="m-0 text-right font-semibold text-text-primary">{row.secondary}</dd></div>
+        {'note' in source && source.note && (
+          <div className="flex justify-between gap-4 py-2.5"><dt className="text-text-dim">Nota</dt><dd className="m-0 text-right font-semibold text-text-primary">{source.note}</dd></div>
+        )}
+      </dl>
+
+      <div className="mt-5">
+        <div className="text-[10px] font-bold uppercase tracking-[0.09em] text-text-dim">Impacto</div>
+        <p className="mb-0 mt-2 text-[12px] leading-5 text-text-secondary">{impactCopy}</p>
+      </div>
+    </aside>
+  )
+}
+
+export function WebMovimientosWorkspace({
+  accounts,
+  cards,
+  accountBalances,
+  selectedMonth,
+  viewCurrency,
+  hidden,
+  initialMovements,
+  today = todayAR(),
+  onOpenSettings,
+}: Props) {
+  const [movements, setMovements] = useState<ApiMovement[]>(initialMovements ?? [])
+  const [loading, setLoading] = useState(initialMovements === undefined)
+  const [failed, setFailed] = useState(false)
+  const [type, setType] = useState<WebMovementType>('all')
+  const [accountId, setAccountId] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
+  const [selectedRowId, setSelectedRowId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (initialMovements !== undefined) return
+    let cancelled = false
+    void fetchAllMovimientosForMonth(selectedMonth)
+      .then((next) => {
+        if (!cancelled) {
+          setMovements(next)
+          setFailed(false)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [initialMovements, selectedMonth])
+
+  const rows = useMemo(() => buildWebMovementRows(movements, accounts, cards), [accounts, cards, movements])
+  const filteredRows = useMemo(
+    () => filterWebMovementRows(rows, { type, accountId, query }),
+    [accountId, query, rows, type],
+  )
+  const groups = useMemo(() => groupWebMovementRows(filteredRows, today), [filteredRows, today])
+  const activityCounts = useMemo(() => buildAccountActivityCounts(rows), [rows])
+  const selectedRow = rows.find((row) => row.id === selectedRowId) ?? null
+  const totalBalance = accountBalances.reduce((sum, account) => sum + account.saldo, 0)
+  const selectedAccount = accountId ? accountBalances.find((account) => account.id === accountId) : null
+
+  return (
+    <section data-web-movimientos-workspace="true" className="mx-auto w-full max-w-[1240px]">
+      <style>{`
+        .web-mov-layout { display:grid; grid-template-columns:minmax(0, 880px) minmax(250px, 280px); gap:24px; align-items:start; }
+        @media (max-width: 1100px) {
+          .web-mov-layout { grid-template-columns:minmax(0, 1fr); }
+          .web-account-rail { order:1; display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:8px; }
+          .web-mov-ledger { order:2; }
+          .web-mov-context-heading { grid-column:1/-1; }
+        }
+        @media (max-width: 680px) {
+          .web-mov-toolbar { grid-template-columns:1fr !important; }
+          .web-mov-header { align-items:flex-start !important; }
+          .web-account-rail { display:flex !important; overflow-x:auto; align-items:stretch; gap:6px; padding:8px !important; scrollbar-width:none; }
+          .web-account-rail::-webkit-scrollbar { display:none; }
+          .web-mov-context-heading { display:none !important; }
+          .web-account-option { min-width:220px; margin-top:0 !important; }
+          .web-account-admin { min-width:156px; margin-top:0 !important; border-top:0 !important; border-left:1px solid rgba(33,120,168,.08); padding-top:0 !important; }
+        }
+      `}</style>
+
+      <header className="web-mov-header mb-5 flex items-end justify-between gap-4">
+        <div>
+          <h1 className="m-0 text-[26px] font-bold tracking-[-0.035em] text-text-primary">Movimientos</h1>
+          <p className="mb-0 mt-1.5 text-[13px] text-text-dim">Todo lo que entró, salió o cambió de lugar.</p>
+        </div>
+        <HomePlusButton accounts={accounts} cards={cards} currency={viewCurrency} month={selectedMonth} label="Nuevo movimiento" />
+      </header>
+
+      <div className="web-mov-toolbar mb-5 grid grid-cols-[minmax(220px,1fr)_180px] gap-2 rounded-[12px] border border-primary/[0.09] bg-white p-2 shadow-[0_1px_3px_rgba(13,24,41,0.03)]">
+        <label className="flex h-9 items-center gap-2 rounded-[9px] bg-bg-secondary px-3">
+          <MagnifyingGlass size={15} className="shrink-0 text-text-dim" />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Buscar descripción, categoría o cuenta…"
+            className="min-w-0 flex-1 border-0 bg-transparent p-0 text-[13px] text-text-primary outline-none placeholder:text-text-disabled"
+          />
+        </label>
+        <select
+          value={type}
+          onChange={(event) => setType(event.target.value as WebMovementType)}
+          aria-label="Filtrar por tipo"
+          className="h-9 rounded-[9px] border border-primary/[0.10] bg-white px-3 text-[12px] font-semibold text-text-secondary outline-none"
+        >
+          {TYPE_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+        </select>
+      </div>
+
+      <div className="web-mov-layout">
+        <main data-web-movement-ledger="true" className="web-mov-ledger min-w-0 overflow-hidden rounded-[14px] border border-primary/[0.09] bg-white shadow-[0_1px_4px_rgba(13,24,41,0.04)]">
+          <div className="flex items-center justify-between gap-4 border-b border-primary/[0.08] px-5 py-3">
+            <div className="min-w-0">
+              <div className="truncate text-[12px] font-semibold text-text-primary">{selectedAccount?.name ?? 'Todas las cuentas'}</div>
+              <div className="mt-0.5 text-[11px] text-text-dim">{filteredRows.length} movimiento{filteredRows.length === 1 ? '' : 's'} en el período</div>
+            </div>
+            {(query || type !== 'all' || accountId) && (
+              <button type="button" onClick={() => { setQuery(''); setType('all'); setAccountId(null) }} className="shrink-0 text-[11px] font-semibold text-primary">Limpiar filtros</button>
+            )}
+          </div>
+
+          {loading ? (
+            <div className="space-y-1 p-5">{Array.from({ length: 7 }, (_, index) => <div key={index} className="skeleton h-[52px] rounded-[8px]" />)}</div>
+          ) : failed ? (
+            <div className="px-6 py-14 text-center"><div className="text-[14px] font-semibold text-text-primary">No pudimos cargar los movimientos</div><p className="mb-0 mt-2 text-[12px] text-text-dim">Recargá la página para volver a intentarlo.</p></div>
+          ) : groups.length === 0 ? (
+            <div className="px-6 py-14 text-center"><div className="text-[14px] font-semibold text-text-primary">No encontramos movimientos</div><p className="mb-0 mt-2 text-[12px] text-text-dim">Probá otra cuenta o limpiá los filtros.</p></div>
+          ) : (
+            groups.map((group) => (
+              <section key={group.date}>
+                <div className="border-b border-primary/[0.07] bg-bg-secondary/70 px-5 py-2 text-[10px] font-bold uppercase tracking-[0.07em] text-text-dim">{group.label}</div>
+                {group.rows.map((row) => {
+                  const selected = row.id === selectedRowId
+                  return (
+                    <button
+                      key={row.id}
+                      type="button"
+                      onClick={() => setSelectedRowId(row.id)}
+                      className={`flex w-full items-center gap-3 border-b border-primary/[0.07] px-5 py-3 text-left transition-colors last:border-b-0 hover:bg-primary/[0.025] ${selected ? 'bg-primary/[0.055]' : 'bg-white'}`}
+                    >
+                      <RowIcon row={row} />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-[13px] font-semibold text-text-primary">{row.title}</span>
+                        <span className="mt-0.5 block truncate text-[11px] text-text-dim">{row.secondary}</span>
+                      </span>
+                      <span className={`shrink-0 text-right text-[13px] font-bold tabular-nums ${row.tone === 'income' || row.tone === 'yield' ? 'text-success' : 'text-text-primary'}`}>{signedAmountLabel(row, hidden)}</span>
+                      <CaretRight size={13} className="shrink-0 text-text-disabled" />
+                    </button>
+                  )
+                })}
+              </section>
+            ))
+          )}
+        </main>
+
+        {selectedRow ? (
+          <MovementDetail row={selectedRow} hidden={hidden} onClose={() => setSelectedRowId(null)} />
+        ) : (
+          <aside data-web-account-context="true" className="web-mov-context web-account-rail rounded-[14px] border border-primary/[0.09] bg-white p-3 shadow-[0_1px_4px_rgba(13,24,41,0.04)]">
+            <div className="web-mov-context-heading flex items-center justify-between px-2 pb-2 pt-1">
+              <div>
+                <div className="text-[10px] font-bold uppercase tracking-[0.09em] text-text-dim">Cuentas</div>
+                <div className="mt-1 text-[11px] text-text-dim">Contexto del ledger</div>
+              </div>
+              <Wallet size={17} className="text-primary" />
+            </div>
+
+            <button type="button" onClick={() => setAccountId(null)} className={`web-account-option mt-1 flex w-full items-center gap-3 rounded-[10px] px-3 py-3 text-left ${accountId === null ? 'bg-primary/[0.08]' : 'hover:bg-bg-secondary'}`}>
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[9px] bg-primary/[0.10] text-primary"><Wallet size={16} /></span>
+              <span className="min-w-0 flex-1"><span className="block text-[12px] font-semibold text-text-primary">Todas las cuentas</span><span className="mt-0.5 block text-[10px] text-text-dim">{rows.length} movimientos</span></span>
+              <span className="shrink-0 text-[12px] font-bold tabular-nums text-text-primary">{hidden ? '••••' : formatAmount(totalBalance, viewCurrency)}</span>
+            </button>
+
+            {accountBalances.map((account) => (
+              <button key={account.id} type="button" onClick={() => setAccountId(account.id)} className={`web-account-option mt-1 flex w-full items-center gap-3 rounded-[10px] px-3 py-3 text-left ${accountId === account.id ? 'bg-primary/[0.08]' : 'hover:bg-bg-secondary'}`}>
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[9px] bg-ocean/[0.09] text-[12px] font-bold text-ocean">{account.name.charAt(0).toUpperCase()}</span>
+                <span className="min-w-0 flex-1"><span className="block truncate text-[12px] font-semibold text-text-primary">{account.name}</span><span className="mt-0.5 block truncate text-[10px] text-text-dim">{accountTypeLabel(account.type)}{account.is_primary ? ' · principal' : ''} · {activityCounts[account.id] ?? 0} mov.</span></span>
+                <span className="shrink-0 text-[12px] font-bold tabular-nums text-text-primary">{hidden ? '••••' : formatAmount(account.saldo, viewCurrency)}</span>
+              </button>
+            ))}
+
+            <button type="button" onClick={onOpenSettings} className="web-account-admin mt-3 flex w-full items-center justify-center gap-2 border-t border-primary/[0.08] px-3 pt-3 text-[11px] font-semibold text-primary">
+              <CreditCard size={13} /> Administrar cuentas
+            </button>
+          </aside>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/components/dashboard/desktop/desktop-chrome.tsx
+++ b/components/dashboard/desktop/desktop-chrome.tsx
@@ -8,7 +8,6 @@ import { BLUE, MAXW } from './desktop-ui'
 export type NavId =
   | 'inicio'
   | 'movimientos'
-  | 'cuentas'
   | 'tarjetas'
   | 'presupuestos'
   | 'metas'
@@ -22,7 +21,6 @@ type CotizacionApiData = {
 const NAV_ITEMS: Array<{ id: NavId; label: string }> = [
   { id: 'inicio', label: 'Panel' },
   { id: 'movimientos', label: 'Movimientos' },
-  { id: 'cuentas', label: 'Cuentas' },
   { id: 'tarjetas', label: 'Tarjetas' },
   { id: 'presupuestos', label: 'Presupuestos' },
   { id: 'metas', label: 'Metas' },

--- a/components/dashboard/desktop/desktop-modules.tsx
+++ b/components/dashboard/desktop/desktop-modules.tsx
@@ -149,7 +149,7 @@ export function CuentasModule({
 }) {
   const total = accounts.reduce((s, a) => s + a.saldo, 0)
   return (
-    <ModuleCard title="Liquidez" tag={`${accounts.length} cuenta${accounts.length !== 1 ? 's' : ''}`} tagTone="muted" action="Ver cuentas" onAction={() => onNav('cuentas')}>
+    <ModuleCard title="Liquidez" tag={`${accounts.length} cuenta${accounts.length !== 1 ? 's' : ''}`} tagTone="muted" action="Ver movimientos" onAction={() => onNav('movimientos')}>
       <div style={{ marginBottom: 6, fontSize: 24, fontWeight: 700, letterSpacing: '-0.025em', color: '#0D1829', fontVariantNumeric: 'tabular-nums' }}>{money(total)}</div>
       <div style={{ fontSize: 12, color: '#90A4B0', marginBottom: 16 }}>Dónde está tu plata hoy</div>
       <div>

--- a/components/dashboard/desktop/movimientos-data.ts
+++ b/components/dashboard/desktop/movimientos-data.ts
@@ -27,7 +27,7 @@ export async function fetchAllMovimientosForMonth(
 
   while (allMovements.length < total) {
     const response = await fetchImpl(
-      `/api/movimientos?month=${encodeURIComponent(month)}&page=${page}&includeYield=false`,
+      `/api/movimientos?month=${encodeURIComponent(month)}&page=${page}`,
     )
     if (!response.ok) {
       throw new Error(`movimientos fetch failed for month ${month} page ${page}`)

--- a/components/dashboard/web-panel/WebPanelTopbar.tsx
+++ b/components/dashboard/web-panel/WebPanelTopbar.tsx
@@ -10,7 +10,6 @@ import type { NavId } from '@/components/dashboard/desktop/desktop-chrome'
 const NAV = [
   { id: 'inicio', label: 'Panel' },
   { id: 'movimientos', label: 'Movimientos' },
-  { id: 'cuentas', label: 'Cuentas' },
   { id: 'tarjetas', label: 'Tarjetas' },
   { id: 'presupuestos', label: 'Presupuestos' },
   { id: 'metas', label: 'Metas' },

--- a/components/web/dashboard/WebDashboardRoute.tsx
+++ b/components/web/dashboard/WebDashboardRoute.tsx
@@ -12,7 +12,7 @@ import { buildCardCycleAmountsMap } from '@/lib/card-cycle-amounts'
 import type { DashboardApiData } from '@/lib/server/dashboard-queries'
 import type { BudgetSnapshot } from '@/lib/budgets/types'
 import { FF_WEB_PANEL_BRIEF_V1 } from '@/lib/flags'
-import { resolveWebPanelNav } from '@/lib/web-panel/navigation'
+import { buildWebNavHref, resolveWebPanelNav } from '@/lib/web-panel/navigation'
 
 type CotizacionApiData = {
   compra: number
@@ -32,6 +32,7 @@ type Props = {
   userEmail: string
   initialData: DashboardApiData
   initialQuote: CotizacionApiData | null
+  initialView: NavId
 }
 
 export function WebDashboardRoute({
@@ -40,9 +41,10 @@ export function WebDashboardRoute({
   userEmail,
   initialData,
   initialQuote,
+  initialView,
 }: Props) {
   const router = useRouter()
-  const [webNav, setWebNav] = useState<NavId>('inicio')
+  const [webNav, setWebNav] = useState<NavId>(initialView)
   const analyticsQuery = useQuery<AnalyticsApiData>({
     queryKey: ['analytics', selectedMonth, viewCurrency, 'web'],
     queryFn: async () => {
@@ -78,10 +80,15 @@ export function WebDashboardRoute({
     )
   }, [analyticsQuery.data, initialData.isCurrentMonth, selectedMonth])
 
+  const navigateWeb = (nav: NavId, month = selectedMonth) => {
+    setWebNav(nav)
+    router.push(buildWebNavHref(nav, { month, currency: viewCurrency }))
+  }
+
   const openWebHref = (href: string) => {
     const nav = resolveWebPanelNav(href)
     if (nav) {
-      setWebNav(nav)
+      navigateWeb(nav)
       return
     }
     router.push(href)
@@ -102,8 +109,8 @@ export function WebDashboardRoute({
         budgetError={budgetQuery.isError}
         compromisos={compromisos}
         quote={initialQuote}
-        onNav={setWebNav}
-        onSelectMonth={(month) => router.push(`/web?month=${month}&currency=${viewCurrency}`)}
+        onNav={navigateWeb}
+        onSelectMonth={(month) => navigateWeb(webNav, month)}
         onOpenSettings={() => router.push('/web/settings')}
         onNavigate={openWebHref}
       />
@@ -125,9 +132,9 @@ export function WebDashboardRoute({
         quote={initialQuote}
         amountsVisible
         initialNav={webNav}
-        onNavChange={setWebNav}
+        onNavChange={navigateWeb}
         onOpenSettings={() => router.push('/web/settings')}
-        onSelectMonth={(month) => router.push(`/web?month=${month}&currency=${viewCurrency}`)}
+        onSelectMonth={(month) => navigateWeb(webNav, month)}
       />
     )
   }

--- a/lib/desktop-movimientos-data.test.ts
+++ b/lib/desktop-movimientos-data.test.ts
@@ -56,8 +56,8 @@ describe('fetchAllMovimientosForMonth', () => {
     const result = await fetchAllMovimientosForMonth('2026-06', fetchMock)
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
-    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/movimientos?month=2026-06&page=1&includeYield=false')
-    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/movimientos?month=2026-06&page=2&includeYield=false')
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/movimientos?month=2026-06&page=1')
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/movimientos?month=2026-06&page=2')
     expect(result).toHaveLength(21)
     expect(result.at(-1)).toEqual(page2[0])
   })

--- a/lib/web-movimientos-model.test.ts
+++ b/lib/web-movimientos-model.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+import type { Account, Card } from '@/types/database'
+import type { ApiMovement } from '@/components/dashboard/desktop/movimientos-data'
+import {
+  buildAccountActivityCounts,
+  buildWebMovementRows,
+  filterWebMovementRows,
+  groupWebMovementRows,
+} from './web-movimientos-model'
+
+const accounts = [
+  { id: 'nacion', name: 'Nación', type: 'bank', is_primary: true },
+  { id: 'mp', name: 'Mercado Pago', type: 'digital', is_primary: false },
+] as Account[]
+
+const cards = [
+  { id: 'visa', name: 'Visa', account_id: 'nacion' },
+] as Card[]
+
+const movements = [
+  {
+    kind: 'expense',
+    data: {
+      id: 'expense-1',
+      description: 'Carrefour',
+      category: 'Alimentos',
+      amount: 48_520,
+      currency: 'ARS',
+      payment_method: 'DEBIT',
+      account_id: 'nacion',
+      card_id: null,
+      date: '2026-07-23',
+      created_at: '2026-07-23T12:00:00Z',
+    },
+  },
+  {
+    kind: 'expense',
+    data: {
+      id: 'expense-2',
+      description: 'Mercado Libre',
+      category: 'Tecnología',
+      amount: 86_900,
+      currency: 'ARS',
+      payment_method: 'CREDIT',
+      account_id: null,
+      card_id: 'visa',
+      date: '2026-07-22',
+      created_at: '2026-07-22T12:00:00Z',
+    },
+  },
+  {
+    kind: 'income',
+    data: {
+      id: 'income-1',
+      description: 'Sueldo',
+      category: 'salary',
+      amount: 1_850_000,
+      currency: 'ARS',
+      account_id: 'nacion',
+      date: '2026-07-23',
+      created_at: '2026-07-23T11:00:00Z',
+    },
+  },
+  {
+    kind: 'transfer',
+    data: {
+      id: 'transfer-1',
+      from_account_id: 'nacion',
+      to_account_id: 'mp',
+      amount_from: 120_000,
+      amount_to: 120_000,
+      currency_from: 'ARS',
+      currency_to: 'ARS',
+      date: '2026-07-23',
+      note: 'Para gastos diarios',
+      created_at: '2026-07-23T10:00:00Z',
+    },
+  },
+  {
+    kind: 'yield',
+    data: {
+      id: 'yield-1',
+      account_id: 'nacion',
+      accountName: 'Nación',
+      amount: 2_430,
+      currency: 'ARS',
+      date: '2026-07-21',
+      dayCount: 3,
+      actualCount: 3,
+      estimatedCount: 0,
+      differenceCount: 0,
+    },
+  },
+] as ApiMovement[]
+
+describe('web movimientos model', () => {
+  it('normalizes every movement kind with account context and finance semantics', () => {
+    const rows = buildWebMovementRows(movements, accounts, cards)
+
+    expect(rows.map((row) => row.id)).toEqual([
+      'expense:expense-1',
+      'expense:expense-2',
+      'income:income-1',
+      'transfer:transfer-1',
+      'yield:yield-1',
+    ])
+    expect(rows[0]).toMatchObject({
+      title: 'Carrefour',
+      secondary: 'Alimentos · Nación',
+      accountIds: ['nacion'],
+      signedAmount: -48_520,
+      tone: 'expense',
+    })
+    expect(rows[1]).toMatchObject({
+      secondary: 'Tecnología · Visa',
+      accountIds: ['nacion'],
+      signedAmount: -86_900,
+    })
+    expect(rows[2]).toMatchObject({ signedAmount: 1_850_000, tone: 'income' })
+    expect(rows[3]).toMatchObject({
+      title: 'Transferencia',
+      secondary: 'Nación → Mercado Pago',
+      accountIds: ['nacion', 'mp'],
+      tone: 'transfer',
+    })
+    expect(rows[4]).toMatchObject({
+      secondary: 'Nación · 3 días reales',
+      accountIds: ['nacion'],
+      signedAmount: 2_430,
+      tone: 'yield',
+    })
+  })
+
+  it('filters by type, both sides of a transfer, and normalized search text', () => {
+    const rows = buildWebMovementRows(movements, accounts, cards)
+
+    expect(filterWebMovementRows(rows, { type: 'transfer', accountId: 'mp', query: '' })).toHaveLength(1)
+    expect(filterWebMovementRows(rows, { type: 'all', accountId: 'nacion', query: 'tecnologia' }).map((row) => row.id)).toEqual([
+      'expense:expense-2',
+    ])
+    expect(filterWebMovementRows(rows, { type: 'income', accountId: null, query: 'NACIÓN' }).map((row) => row.id)).toEqual([
+      'income:income-1',
+    ])
+  })
+
+  it('groups newest dates first and counts account activity without double-counting rows', () => {
+    const rows = buildWebMovementRows(movements, accounts, cards)
+    const groups = groupWebMovementRows(rows, '2026-07-23')
+
+    expect(groups.map((group) => group.label)).toEqual([
+      'Hoy · 23 de julio',
+      'Ayer · 22 de julio',
+      'Martes · 21 de julio',
+    ])
+    expect(buildAccountActivityCounts(rows)).toEqual({ nacion: 5, mp: 1 })
+  })
+})

--- a/lib/web-movimientos-model.ts
+++ b/lib/web-movimientos-model.ts
@@ -1,0 +1,185 @@
+import type { ApiMovement } from '@/components/dashboard/desktop/movimientos-data'
+import type { Account, Card } from '@/types/database'
+import { toDateOnly } from '@/lib/format'
+
+export type WebMovementType = 'all' | 'expense' | 'income' | 'transfer' | 'yield'
+
+export type WebMovementRow = {
+  id: string
+  kind: Exclude<WebMovementType, 'all'>
+  date: string
+  title: string
+  secondary: string
+  accountIds: string[]
+  category: string | null
+  amount: number
+  signedAmount: number
+  currency: 'ARS' | 'USD'
+  secondaryAmount?: number
+  secondaryCurrency?: 'ARS' | 'USD'
+  tone: 'expense' | 'income' | 'transfer' | 'yield'
+  source: ApiMovement
+}
+
+export type WebMovementFilters = {
+  type: WebMovementType
+  accountId: string | null
+  query: string
+}
+
+export type WebMovementGroup = {
+  date: string
+  label: string
+  rows: WebMovementRow[]
+}
+
+const normalizeSearch = (value: string) =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase('es-AR')
+    .trim()
+
+const accountNameMap = (accounts: Account[]) => new Map(accounts.map((account) => [account.id, account.name]))
+
+function accountName(id: string | null | undefined, names: Map<string, string>): string {
+  if (!id) return 'Sin cuenta'
+  return names.get(id) ?? 'Cuenta'
+}
+
+export function buildWebMovementRows(
+  movements: ApiMovement[],
+  accounts: Account[],
+  cards: Card[],
+): WebMovementRow[] {
+  const names = accountNameMap(accounts)
+  const cardsById = new Map(cards.map((card) => [card.id, card]))
+
+  return movements.map((movement) => {
+    if (movement.kind === 'expense') {
+      const expense = movement.data
+      const card = expense.card_id ? cardsById.get(expense.card_id) : null
+      const linkedAccountId = expense.account_id ?? card?.account_id ?? null
+      const sourceLabel = card?.name ?? accountName(expense.account_id, names)
+
+      return {
+        id: `expense:${expense.id}`,
+        kind: 'expense',
+        date: toDateOnly(expense.date),
+        title: expense.description || 'Gasto',
+        secondary: [expense.category, sourceLabel].filter(Boolean).join(' · '),
+        accountIds: linkedAccountId ? [linkedAccountId] : [],
+        category: expense.category,
+        amount: Number(expense.amount),
+        signedAmount: -Number(expense.amount),
+        currency: expense.currency,
+        tone: 'expense',
+        source: movement,
+      }
+    }
+
+    if (movement.kind === 'income') {
+      const income = movement.data
+      return {
+        id: `income:${income.id}`,
+        kind: 'income',
+        date: toDateOnly(income.date),
+        title: income.description || 'Ingreso',
+        secondary: ['Ingresos', accountName(income.account_id, names)].filter(Boolean).join(' · '),
+        accountIds: income.account_id ? [income.account_id] : [],
+        category: income.category,
+        amount: Number(income.amount),
+        signedAmount: Number(income.amount),
+        currency: income.currency,
+        tone: 'income',
+        source: movement,
+      }
+    }
+
+    if (movement.kind === 'transfer') {
+      const transfer = movement.data
+      return {
+        id: `transfer:${transfer.id}`,
+        kind: 'transfer',
+        date: toDateOnly(transfer.date),
+        title: 'Transferencia',
+        secondary: `${accountName(transfer.from_account_id, names)} → ${accountName(transfer.to_account_id, names)}`,
+        accountIds: [...new Set([transfer.from_account_id, transfer.to_account_id].filter(Boolean))],
+        category: null,
+        amount: Number(transfer.amount_from),
+        signedAmount: 0,
+        currency: transfer.currency_from,
+        secondaryAmount: Number(transfer.amount_to),
+        secondaryCurrency: transfer.currency_to,
+        tone: 'transfer',
+        source: movement,
+      }
+    }
+
+    const entry = movement.data
+    const dayCopy = `${entry.dayCount} día${entry.dayCount === 1 ? '' : 's'}`
+    const statusCopy = entry.actualCount === entry.dayCount ? 'reales' : entry.estimatedCount === entry.dayCount ? 'estimados' : 'registrados'
+    return {
+      id: `yield:${entry.id}`,
+      kind: 'yield',
+      date: toDateOnly(entry.date),
+      title: 'Rendimiento diario',
+      secondary: `${entry.accountName} · ${dayCopy} ${statusCopy}`,
+      accountIds: entry.account_id ? [entry.account_id] : [],
+      category: null,
+      amount: Number(entry.amount),
+      signedAmount: Number(entry.amount),
+      currency: entry.currency,
+      tone: 'yield',
+      source: movement,
+    }
+  })
+}
+
+export function filterWebMovementRows(
+  rows: WebMovementRow[],
+  filters: WebMovementFilters,
+): WebMovementRow[] {
+  const query = normalizeSearch(filters.query)
+  return rows.filter((row) => {
+    if (filters.type !== 'all' && row.kind !== filters.type) return false
+    if (filters.accountId && !row.accountIds.includes(filters.accountId)) return false
+    if (!query) return true
+    return normalizeSearch(`${row.title} ${row.secondary} ${row.category ?? ''}`).includes(query)
+  })
+}
+
+function formatGroupLabel(date: string, today: string): string {
+  const parsed = new Date(`${date}T12:00:00-03:00`)
+  if (Number.isNaN(parsed.getTime())) return 'Sin fecha'
+  const longDate = parsed.toLocaleDateString('es-AR', { day: 'numeric', month: 'long' })
+  if (date === today) return `Hoy · ${longDate}`
+
+  const yesterday = new Date(`${today}T12:00:00-03:00`)
+  yesterday.setDate(yesterday.getDate() - 1)
+  if (date === yesterday.toISOString().slice(0, 10)) return `Ayer · ${longDate}`
+
+  const weekday = parsed.toLocaleDateString('es-AR', { weekday: 'long' })
+  return `${weekday.charAt(0).toUpperCase()}${weekday.slice(1)} · ${longDate}`
+}
+
+export function groupWebMovementRows(rows: WebMovementRow[], today: string): WebMovementGroup[] {
+  const grouped = new Map<string, WebMovementRow[]>()
+  for (const row of rows) {
+    const current = grouped.get(row.date) ?? []
+    current.push(row)
+    grouped.set(row.date, current)
+  }
+
+  return [...grouped.entries()]
+    .sort(([left], [right]) => right.localeCompare(left))
+    .map(([date, groupRows]) => ({ date, label: formatGroupLabel(date, today), rows: groupRows }))
+}
+
+export function buildAccountActivityCounts(rows: WebMovementRow[]): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const row of rows) {
+    for (const id of new Set(row.accountIds)) counts[id] = (counts[id] ?? 0) + 1
+  }
+  return counts
+}

--- a/lib/web-movimientos-workspace.test.ts
+++ b/lib/web-movimientos-workspace.test.ts
@@ -1,0 +1,61 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { Account, Card } from '@/types/database'
+import type { ApiMovement } from '@/components/dashboard/desktop/movimientos-data'
+import { WebMovimientosWorkspace } from '@/components/dashboard/desktop/WebMovimientosWorkspace'
+
+const accounts = [
+  { id: 'nacion', name: 'Nación', type: 'bank', is_primary: true },
+  { id: 'mp', name: 'Mercado Pago', type: 'digital', is_primary: false },
+] as Account[]
+
+const movements = [
+  {
+    kind: 'expense',
+    data: {
+      id: 'expense-1',
+      description: 'Carrefour',
+      category: 'Alimentos',
+      amount: 48_520,
+      currency: 'ARS',
+      payment_method: 'DEBIT',
+      account_id: 'nacion',
+      card_id: null,
+      date: '2026-07-23',
+      created_at: '2026-07-23T12:00:00Z',
+    },
+  },
+] as ApiMovement[]
+
+describe('WebMovimientosWorkspace', () => {
+  it('renders a bounded ledger and account context without dashboard KPI cards', () => {
+    const html = renderToStaticMarkup(
+      createElement(WebMovimientosWorkspace, {
+        accounts,
+        cards: [] as Card[],
+        accountBalances: [
+          { id: 'nacion', name: 'Nación', type: 'bank', is_primary: true, saldo: 1_820_500 },
+          { id: 'mp', name: 'Mercado Pago', type: 'digital', is_primary: false, saldo: 584_600 },
+        ],
+        selectedMonth: '2026-07',
+        viewCurrency: 'ARS',
+        hidden: false,
+        initialMovements: movements,
+        today: '2026-07-23',
+        onOpenSettings: () => undefined,
+      }),
+    )
+
+    expect(html).toContain('data-web-movimientos-workspace="true"')
+    expect(html).toContain('data-web-movement-ledger="true"')
+    expect(html).toContain('data-web-account-context="true"')
+    expect(html).toContain('web-account-rail')
+    expect(html).toContain('Todas las cuentas')
+    expect(html).toContain('Carrefour')
+    expect(html).toContain('Alimentos · Nación')
+    expect(html).toContain('Nuevo movimiento')
+    expect(html).not.toContain('Gastos del mes')
+    expect(html).not.toContain('Margen')
+  })
+})

--- a/lib/web-panel/navigation.test.ts
+++ b/lib/web-panel/navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveWebPanelNav } from './navigation'
+import { buildWebNavHref, parseWebNavView, resolveWebPanelNav } from './navigation'
 
 describe('resolveWebPanelNav', () => {
   it.each([
@@ -18,5 +18,22 @@ describe('resolveWebPanelNav', () => {
 
   it('deja pasar una ruta sin equivalente en el Dashboard', () => {
     expect(resolveWebPanelNav('/web/settings')).toBeNull()
+  })
+})
+
+describe('web navigation state', () => {
+  it('parses only current desktop destinations and rejects the removed cuentas tab', () => {
+    expect(parseWebNavView('movimientos')).toBe('movimientos')
+    expect(parseWebNavView('cuentas')).toBe('inicio')
+    expect(parseWebNavView(undefined)).toBe('inicio')
+  })
+
+  it('builds stable web hrefs while preserving month and currency', () => {
+    expect(buildWebNavHref('movimientos', { month: '2026-07', currency: 'USD' })).toBe(
+      '/web?month=2026-07&currency=USD&view=movimientos',
+    )
+    expect(buildWebNavHref('inicio', { month: '2026-07', currency: 'ARS' })).toBe(
+      '/web?month=2026-07&currency=ARS',
+    )
   })
 })

--- a/lib/web-panel/navigation.ts
+++ b/lib/web-panel/navigation.ts
@@ -1,5 +1,29 @@
 import type { NavId } from '@/components/dashboard/desktop/desktop-chrome'
 
+const WEB_NAV_IDS = new Set<NavId>([
+  'inicio',
+  'movimientos',
+  'tarjetas',
+  'presupuestos',
+  'metas',
+  'instrumentos',
+  'analisis',
+])
+
+export function parseWebNavView(value: string | undefined): NavId {
+  if (!value || !WEB_NAV_IDS.has(value as NavId)) return 'inicio'
+  return value as NavId
+}
+
+export function buildWebNavHref(
+  view: NavId,
+  context: { month: string; currency: 'ARS' | 'USD' },
+): string {
+  const params = new URLSearchParams({ month: context.month, currency: context.currency })
+  if (view !== 'inicio') params.set('view', view)
+  return `/web?${params.toString()}`
+}
+
 export function resolveWebPanelNav(href: string): NavId | null {
   const url = new URL(href, 'https://gota.local')
 


### PR DESCRIPTION
## Resultado visible
- Reemplaza Movimientos por un ledger compacto con rail contextual de cuentas
- Integra Cuentas como filtro/contexto y elimina su tab primaria
- Agrega búsqueda, filtro por tipo y detalle contextual
- Incluye gastos, ingresos, transferencias y rendimientos
- Persiste la vista Web en `?view=movimientos` y preserva back/forward
- Convierte cuentas en banda horizontal en narrow Web

## Alcance protegido
- No rediseña Home ni las demás secundarias
- No agrega schema ni APIs paralelas
- Retira la preview demo antes del commit

## Verificación
- `npm test`: 69 archivos / 488 tests verdes
- ESLint focalizado: verde
- `npx tsc --noEmit`: verde
- `npm run build`: verde
- `git diff --check`: verde
- QA visual desktop + narrow sobre componente real con fixtures representativas
