### PR TITLE
fix(web): close movimientos review gaps

### DIFF
--- a/app/api/movimientos/route.ts
+++ b/app/api/movimientos/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getCurrentMonth, addMonths } from '@/lib/dates'
-import { todayAR, toDateOnly } from '@/lib/format'
+import { todayAR } from '@/lib/format'
 import {
   isCardPayment,
   isCreditAccruedExpense,
   isPerceivedExpense,
 } from '@/lib/movement-classification'
 import { aggregateYieldDailyEntriesForMovements, type YieldMonthlyMovementData } from '@/lib/movimientos-yield'
+import { paginateMovements } from '@/lib/movimientos-pagination'
 import type { Account, Card, Expense, IncomeEntry, Transfer, YieldDailyEntry } from '@/types/database'
 
 const PAGE_SIZE = 20
@@ -21,11 +22,6 @@ type ApiMovement =
   | { kind: 'income'; data: IncomeEntry }
   | { kind: 'transfer'; data: Transfer }
   | { kind: 'yield'; data: YieldMonthlyMovementData }
-
-function getMovementDate(mv: ApiMovement): string {
-  if (mv.kind === 'yield') return toDateOnly(mv.data.date)
-  return toDateOnly(mv.data.date)
-}
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -266,25 +262,12 @@ export async function GET(request: Request) {
   const todayStr = todayAR()
 
   const allMovements: ApiMovement[] = [
-    ...(page === 1 ? yieldMovements : []),
+    ...yieldMovements,
     ...incomeMovements,
     ...transferMovements,
     ...expenseMovements,
-  ].sort((a, b) => {
-    const dateA = getMovementDate(a)
-    const dateB = getMovementDate(b)
-    const aFuture = dateA > todayStr
-    const bFuture = dateB > todayStr
-    if (aFuture !== bFuture) return aFuture ? 1 : -1
-    if (dateB !== dateA) return dateB.localeCompare(dateA)
-    const caA = a.kind !== 'yield' ? a.data.created_at : ''
-    const caB = b.kind !== 'yield' ? b.data.created_at : ''
-    return caB.localeCompare(caA)
-  })
-
-  const total = allMovements.length
-  const offset = (page - 1) * PAGE_SIZE
-  const movements = allMovements.slice(offset, offset + PAGE_SIZE)
+  ]
+  const { movements, total } = paginateMovements(allMovements, page, PAGE_SIZE, todayStr)
 
   const sumCurrency: 'ARS' | 'USD' =
     activeMonedas.length === 1 && activeMonedas[0] === 'USD' ? 'USD' : 'ARS'

--- a/components/dashboard/CardPaymentForm.tsx
+++ b/components/dashboard/CardPaymentForm.tsx
@@ -12,6 +12,7 @@ interface Props {
   accounts: Account[]
   cards: Card[]
   onClose: () => void
+  onSaved?: () => void
   defaultCurrency: Currency
 }
 
@@ -20,7 +21,7 @@ function formatMoneyInput(n: number): string {
   return new Intl.NumberFormat('es-AR', { maximumFractionDigits: 0 }).format(n)
 }
 
-export function CardPaymentForm({ accounts, cards, onClose, defaultCurrency }: Props) {
+export function CardPaymentForm({ accounts, cards, onClose, onSaved, defaultCurrency }: Props) {
   const router = useRouter()
   const queryClient = useQueryClient()
   const activeAccounts = accounts.filter((account) => !account.archived)
@@ -111,6 +112,7 @@ export function CardPaymentForm({ accounts, cards, onClose, defaultCurrency }: P
       queryClient.invalidateQueries({ queryKey: ['analytics'] })
       queryClient.invalidateQueries({ queryKey: ['account-breakdown'] })
       router.refresh()
+      onSaved?.()
       onClose()
     } catch (submissionError) {
       setError(submissionError instanceof Error ? submissionError.message : 'Error al registrar el pago')

--- a/components/dashboard/CuotasEnCursoSheet.tsx
+++ b/components/dashboard/CuotasEnCursoSheet.tsx
@@ -10,11 +10,12 @@ import type { Card } from '@/types/database'
 
 interface Props {
   onClose: () => void
+  onSaved?: () => void
   currency: 'ARS' | 'USD'
   cards: Card[]
 }
 
-export function CuotasEnCursoSheet({ onClose, currency: defaultCurrency, cards }: Props) {
+export function CuotasEnCursoSheet({ onClose, onSaved, currency: defaultCurrency, cards }: Props) {
   const router = useRouter()
   const activeCards = cards.filter((c) => !c.archived)
 
@@ -63,6 +64,7 @@ export function CuotasEnCursoSheet({ onClose, currency: defaultCurrency, cards }
       })
       if (!res.ok) throw new Error()
       router.refresh()
+      onSaved?.()
       onClose()
     } catch {
       alert('Error al guardar. Intentá de nuevo.')

--- a/components/dashboard/HomePlusButton.tsx
+++ b/components/dashboard/HomePlusButton.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Plus, ArrowFatLineUp, ArrowsClockwise, X, CreditCard, ArrowsLeftRight, TrendUp } from '@phosphor-icons/react'
+import { Plus, ArrowFatLineUp, ArrowsClockwise, X, CreditCard, ArrowsLeftRight, TrendUp, Receipt } from '@phosphor-icons/react'
 import { Modal } from '@/components/ui/Modal'
 import { IncomeModal } from './IncomeModal'
 import { SubscriptionSheet } from '@/components/subscriptions/SubscriptionSheet'
@@ -9,8 +9,11 @@ import { CuotasEnCursoSheet } from './CuotasEnCursoSheet'
 import { TransferForm } from './TransferForm'
 import { CardPaymentForm } from './CardPaymentForm'
 import { InstrumentForm } from '@/components/instruments/InstrumentForm'
+import { SmartInput } from './SmartInput'
 import { FF_INSTRUMENTS } from '@/lib/flags'
 import type { Account, Card } from '@/types/database'
+
+export const HOME_PLUS_EXPENSE_LABEL = 'Gasto común'
 
 interface Props {
   accounts: Account[]
@@ -19,13 +22,18 @@ interface Props {
   month: string
   onBlue?: boolean
   label?: string
+  onMovementCreated?: () => void
 }
 
-type Sheet = null | 'action' | 'income' | 'subscription' | 'cuotas' | 'transfer' | 'pago_tarjeta' | 'instrumento'
+type Sheet = null | 'action' | 'expense' | 'income' | 'subscription' | 'cuotas' | 'transfer' | 'pago_tarjeta' | 'instrumento'
 
-export function HomePlusButton({ accounts, currency, cards, onBlue = false, label }: Props) {
+export function HomePlusButton({ accounts, currency, cards, onBlue = false, label, onMovementCreated }: Props) {
   const [sheet, setSheet] = useState<Sheet>(null)
   const activeCards = cards.filter((card) => !card.archived)
+  const handleSmartExpenseSaved = () => {
+    setSheet(null)
+    onMovementCreated?.()
+  }
 
   return (
     <>
@@ -57,6 +65,19 @@ export function HomePlusButton({ accounts, currency, cards, onBlue = false, labe
             </button>
           </div>
           <div className="flex flex-col">
+            <button
+              onClick={() => setSheet('expense')}
+              className="flex w-full items-center gap-4 border-b border-border-subtle py-[13px] text-left transition-colors"
+            >
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-warning/10">
+                <Receipt weight="regular" size={18} className="text-warning" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-text-primary">{HOME_PLUS_EXPENSE_LABEL}</p>
+                <p className="text-xs text-text-tertiary">Escribí algo como “supermercado 24500”</p>
+              </div>
+            </button>
+
             <button
               onClick={() => setSheet('income')}
               className="flex w-full items-center gap-4 border-b border-border-subtle py-[13px] text-left transition-colors"
@@ -173,11 +194,27 @@ export function HomePlusButton({ accounts, currency, cards, onBlue = false, labe
         </Modal>
       )}
 
+      {sheet === 'expense' && (
+        <Modal open onClose={() => setSheet(null)}>
+          <div className="mb-4 flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-base font-semibold text-text-primary">Nuevo gasto</h2>
+              <p className="mt-1 text-xs text-text-tertiary">Gota completa los datos y te deja revisarlos antes de guardar.</p>
+            </div>
+            <button onClick={() => setSheet(null)} aria-label="Cerrar" className="rounded-full p-1.5 text-text-disabled hover:bg-bg-tertiary hover:text-text-primary">
+              <X weight="bold" size={16} />
+            </button>
+          </div>
+          <SmartInput cards={cards} accounts={accounts} onAfterSave={handleSmartExpenseSaved} previewMode="embedded" />
+        </Modal>
+      )}
+
       {sheet === 'income' && (
         <IncomeModal
           accounts={accounts}
           defaultCurrency={currency}
           onClose={() => setSheet(null)}
+          onSaved={onMovementCreated}
         />
       )}
 
@@ -193,13 +230,14 @@ export function HomePlusButton({ accounts, currency, cards, onBlue = false, labe
       {sheet === 'cuotas' && (
         <CuotasEnCursoSheet
           onClose={() => setSheet(null)}
+          onSaved={onMovementCreated}
           currency={currency}
           cards={cards}
         />
       )}
 
       {sheet === 'transfer' && (
-        <TransferForm accounts={accounts} onClose={() => setSheet(null)} />
+        <TransferForm accounts={accounts} onClose={() => setSheet(null)} onSaved={onMovementCreated} />
       )}
 
       {sheet === 'pago_tarjeta' && (
@@ -208,6 +246,7 @@ export function HomePlusButton({ accounts, currency, cards, onBlue = false, labe
           cards={cards}
           defaultCurrency={currency}
           onClose={() => setSheet(null)}
+          onSaved={onMovementCreated}
         />
       )}
 

--- a/components/dashboard/IncomeModal.tsx
+++ b/components/dashboard/IncomeModal.tsx
@@ -12,6 +12,7 @@ interface Props {
   accounts: Account[]
   defaultCurrency: 'ARS' | 'USD'
   onClose: () => void
+  onSaved?: () => void
   prefill?: {
     amount: number
     currency: 'ARS' | 'USD'
@@ -34,7 +35,7 @@ function AccountIcon({ type, size = 13 }: { type: Account['type']; size?: number
   return <Bank weight="duotone" size={size} />
 }
 
-export function IncomeModal({ accounts, defaultCurrency, onClose, prefill, recurringIncomeId }: Props) {
+export function IncomeModal({ accounts, defaultCurrency, onClose, onSaved, prefill, recurringIncomeId }: Props) {
   const router = useRouter()
   const queryClient = useQueryClient()
   const [amount, setAmount] = useState(() => prefill ? String(prefill.amount) : '')
@@ -86,6 +87,7 @@ export function IncomeModal({ accounts, defaultCurrency, onClose, prefill, recur
       queryClient.invalidateQueries({ queryKey: ['dashboard'] })
       queryClient.invalidateQueries({ queryKey: ['account-breakdown'] })
       router.refresh()
+      onSaved?.()
       onClose()
     } catch {
       alert('Error al registrar ingreso. Intentá de nuevo.')

--- a/components/dashboard/ParsePreview.tsx
+++ b/components/dashboard/ParsePreview.tsx
@@ -31,6 +31,7 @@ interface ParsePreviewProps {
   accounts: Account[]
   onSave: () => void
   onCancel: () => void
+  embedded?: boolean
 }
 
 type SourceKey = string
@@ -81,7 +82,7 @@ function fromDateInput(dateStr: string): string {
   return dateInputToISO(dateStr)
 }
 
-export function ParsePreview({ data, cards, accounts, onSave, onCancel }: ParsePreviewProps) {
+export function ParsePreview({ data, cards, accounts, onSave, onCancel, embedded = false }: ParsePreviewProps) {
   const [form, setForm] = useState<ParsedData>({
     ...data,
     date: toDateInput(data.date),
@@ -202,8 +203,8 @@ export function ParsePreview({ data, cards, accounts, onSave, onCancel }: ParseP
     onCancel()
   }
 
-  return (
-    <Modal open onClose={handleCancel}>
+  const content = (
+    <div data-parse-preview-inline={embedded ? 'true' : undefined}>
       <div className="mx-auto mb-5 h-1 w-10 rounded-full bg-text-disabled sm:hidden" />
 
       <h2 className="text-lg font-semibold text-text-primary">Confirmar gasto</h2>
@@ -469,6 +470,9 @@ export function ParsePreview({ data, cards, accounts, onSave, onCancel }: ParseP
           Cancelar
         </button>
       </div>
-    </Modal>
+    </div>
   )
+
+  if (embedded) return content
+  return <Modal open onClose={handleCancel}>{content}</Modal>
 }

--- a/components/dashboard/SmartInput.tsx
+++ b/components/dashboard/SmartInput.tsx
@@ -28,6 +28,7 @@ interface SmartInputProps {
   onFocusChange?: (focused: boolean) => void
   variant?: 'default' | 'bottom-zone'
   focusSignal?: number
+  previewMode?: 'modal' | 'embedded'
 }
 
 type InputMethod = 'text' | 'voice'
@@ -45,6 +46,7 @@ export function SmartInput({
   onFocusChange,
   variant = 'default',
   focusSignal = 0,
+  previewMode = 'modal',
 }: SmartInputProps) {
   const router = useRouter()
   const [input, setInput] = useState('')
@@ -346,6 +348,7 @@ export function SmartInput({
           accounts={accounts}
           onSave={handleSave}
           onCancel={handleCancel}
+          embedded={previewMode === 'embedded'}
         />
       )}
     </>

--- a/components/dashboard/TransferForm.tsx
+++ b/components/dashboard/TransferForm.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQueryClient } from '@tanstack/react-query'
-import { Bank, Wallet, DeviceMobileSpeaker } from '@phosphor-icons/react'
+
 import { Modal } from '@/components/ui/Modal'
 import { todayAR } from '@/lib/format'
 import type { Account } from '@/types/database'
@@ -11,13 +11,9 @@ import type { Account } from '@/types/database'
 interface Props {
   accounts: Account[]
   onClose: () => void
+  onSaved?: () => void
 }
 
-function AccountIcon({ type, size = 14 }: { type: Account['type']; size?: number }) {
-  if (type === 'cash') return <Wallet weight="duotone" size={size} />
-  if (type === 'digital') return <DeviceMobileSpeaker weight="duotone" size={size} />
-  return <Bank weight="duotone" size={size} />
-}
 
 /** "1234.56" → "1.234,56" */
 function toAR(raw: string): string {
@@ -36,7 +32,7 @@ function fromAR(display: string): string {
   return clean
 }
 
-export function TransferForm({ accounts, onClose }: Props) {
+export function TransferForm({ accounts, onClose, onSaved }: Props) {
   const router = useRouter()
   const queryClient = useQueryClient()
   const activeAccounts = accounts.filter((a) => !a.archived)
@@ -159,6 +155,7 @@ export function TransferForm({ accounts, onClose }: Props) {
       queryClient.invalidateQueries({ queryKey: ['dashboard'] })
       queryClient.invalidateQueries({ queryKey: ['account-breakdown'] })
       router.refresh()
+      onSaved?.()
       onClose()
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Error al guardar')

--- a/components/dashboard/desktop/WebMovimientosWorkspace.tsx
+++ b/components/dashboard/desktop/WebMovimientosWorkspace.tsx
@@ -23,6 +23,12 @@ import {
   type WebMovementType,
 } from '@/lib/web-movimientos-model'
 import { formatAmount, todayAR } from '@/lib/format'
+import {
+  resolveMovementsResource,
+  resolveSelectedMovementId,
+  type MovementSelection,
+  type MovementsResource,
+} from '@/lib/web-movimientos-resource'
 import type { Account, Card } from '@/types/database'
 
 type AccountBalance = {
@@ -59,8 +65,16 @@ function accountTypeLabel(type: string): string {
   return 'Efectivo'
 }
 
-function signedAmountLabel(row: WebMovementRow, hidden: boolean): string {
+function movementAmountLabel(row: WebMovementRow, hidden: boolean): string {
   if (hidden) return '••••••'
+  if (
+    row.kind === 'transfer' &&
+    row.secondaryAmount !== undefined &&
+    row.secondaryCurrency !== undefined &&
+    (row.currency !== row.secondaryCurrency || row.amount !== row.secondaryAmount)
+  ) {
+    return `${formatAmount(row.amount, row.currency)} → ${formatAmount(row.secondaryAmount, row.secondaryCurrency)}`
+  }
   const prefix = row.tone === 'expense' ? '−' : row.tone === 'income' || row.tone === 'yield' ? '+' : ''
   return `${prefix}${formatAmount(row.amount, row.currency)}`
 }
@@ -87,7 +101,7 @@ function RowIcon({ row }: { row: WebMovementRow }) {
   )
 }
 
-function MovementDetail({ row, hidden, onClose }: { row: WebMovementRow; hidden: boolean; onClose: () => void }) {
+export function MovementDetail({ row, hidden, onClose }: { row: WebMovementRow; hidden: boolean; onClose: () => void }) {
   const source = row.source.data
   const dateLabel = new Date(`${row.date}T12:00:00-03:00`).toLocaleDateString('es-AR', {
     weekday: 'long',
@@ -104,14 +118,14 @@ function MovementDetail({ row, hidden, onClose }: { row: WebMovementRow; hidden:
           : 'Sumado al saldo de la cuenta como rendimiento del instrumento.'
 
   return (
-    <aside data-web-account-context="true" className="web-mov-context rounded-[14px] border border-primary/[0.09] bg-white p-5 shadow-[0_1px_4px_rgba(13,24,41,0.04)]">
+    <aside data-web-account-context="true" data-web-movement-detail="true" aria-label="Detalle del movimiento" className="web-mov-context web-movement-detail rounded-[14px] border border-primary/[0.09] bg-white p-5 shadow-[0_1px_4px_rgba(13,24,41,0.04)]">
       <button type="button" onClick={onClose} className="mb-5 inline-flex items-center gap-1.5 text-[12px] font-semibold text-primary">
         <ArrowLeft size={13} weight="bold" /> Volver a cuentas
       </button>
       <div className="mb-2 text-[10px] font-bold uppercase tracking-[0.09em] text-text-dim">{row.kind === 'expense' ? 'Gasto' : row.kind === 'income' ? 'Ingreso' : row.kind === 'transfer' ? 'Transferencia' : 'Rendimiento'}</div>
       <h2 className="m-0 text-[20px] font-bold tracking-[-0.025em] text-text-primary">{row.title}</h2>
       <div className={`mt-5 text-[28px] font-extrabold tabular-nums tracking-[-0.04em] ${row.tone === 'income' || row.tone === 'yield' ? 'text-success' : 'text-text-primary'}`}>
-        {signedAmountLabel(row, hidden)}
+        {movementAmountLabel(row, hidden)}
       </div>
       <div className="mt-1 capitalize text-[12px] text-text-dim">{dateLabel}</div>
 
@@ -144,13 +158,17 @@ export function WebMovimientosWorkspace({
   today = todayAR(),
   onOpenSettings,
 }: Props) {
-  const [movements, setMovements] = useState<ApiMovement[]>(initialMovements ?? [])
-  const [loading, setLoading] = useState(initialMovements === undefined)
-  const [failed, setFailed] = useState(false)
+  const [reloadVersion, setReloadVersion] = useState(0)
+  const requestKey = `${selectedMonth}:${reloadVersion}`
+  const [resource, setResource] = useState<MovementsResource>({
+    key: initialMovements === undefined ? '' : requestKey,
+    movements: initialMovements ?? [],
+    failed: false,
+  })
   const [type, setType] = useState<WebMovementType>('all')
   const [accountId, setAccountId] = useState<string | null>(null)
   const [query, setQuery] = useState('')
-  const [selectedRowId, setSelectedRowId] = useState<string | null>(null)
+  const [selection, setSelection] = useState<MovementSelection>({ key: requestKey, id: null })
 
   useEffect(() => {
     if (initialMovements !== undefined) return
@@ -158,20 +176,21 @@ export function WebMovimientosWorkspace({
     void fetchAllMovimientosForMonth(selectedMonth)
       .then((next) => {
         if (!cancelled) {
-          setMovements(next)
-          setFailed(false)
+          setResource({ key: requestKey, movements: next, failed: false })
         }
       })
       .catch(() => {
-        if (!cancelled) setFailed(true)
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
+        if (!cancelled) setResource({ key: requestKey, movements: [], failed: true })
       })
     return () => {
       cancelled = true
     }
-  }, [initialMovements, selectedMonth])
+  }, [initialMovements, requestKey, selectedMonth])
+
+  const resourceState = initialMovements === undefined
+    ? resolveMovementsResource(resource, requestKey)
+    : { movements: initialMovements, loading: false, failed: false }
+  const { movements, loading, failed } = resourceState
 
   const rows = useMemo(() => buildWebMovementRows(movements, accounts, cards), [accounts, cards, movements])
   const filteredRows = useMemo(
@@ -180,6 +199,7 @@ export function WebMovimientosWorkspace({
   )
   const groups = useMemo(() => groupWebMovementRows(filteredRows, today), [filteredRows, today])
   const activityCounts = useMemo(() => buildAccountActivityCounts(rows), [rows])
+  const selectedRowId = resolveSelectedMovementId(selection, requestKey)
   const selectedRow = rows.find((row) => row.id === selectedRowId) ?? null
   const totalBalance = accountBalances.reduce((sum, account) => sum + account.saldo, 0)
   const selectedAccount = accountId ? accountBalances.find((account) => account.id === accountId) : null
@@ -188,10 +208,14 @@ export function WebMovimientosWorkspace({
     <section data-web-movimientos-workspace="true" className="mx-auto w-full max-w-[1240px]">
       <style>{`
         .web-mov-layout { display:grid; grid-template-columns:minmax(0, 880px) minmax(250px, 280px); gap:24px; align-items:start; }
+        .web-mov-ledger { grid-column:1; grid-row:1; }
+        .web-mov-context { grid-column:2; grid-row:1; }
         @media (max-width: 1100px) {
           .web-mov-layout { grid-template-columns:minmax(0, 1fr); }
           .web-account-rail { order:1; display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:8px; }
-          .web-mov-ledger { order:2; }
+          .web-movement-detail { order:1; }
+          .web-mov-ledger { order:2; grid-column:1; grid-row:auto; }
+          .web-mov-context { grid-column:1; grid-row:auto; }
           .web-mov-context-heading { grid-column:1/-1; }
         }
         @media (max-width: 680px) {
@@ -210,7 +234,14 @@ export function WebMovimientosWorkspace({
           <h1 className="m-0 text-[26px] font-bold tracking-[-0.035em] text-text-primary">Movimientos</h1>
           <p className="mb-0 mt-1.5 text-[13px] text-text-dim">Todo lo que entró, salió o cambió de lugar.</p>
         </div>
-        <HomePlusButton accounts={accounts} cards={cards} currency={viewCurrency} month={selectedMonth} label="Nuevo movimiento" />
+        <HomePlusButton
+          accounts={accounts}
+          cards={cards}
+          currency={viewCurrency}
+          month={selectedMonth}
+          label="Nuevo movimiento"
+          onMovementCreated={() => setReloadVersion((version) => version + 1)}
+        />
       </header>
 
       <div className="web-mov-toolbar mb-5 grid grid-cols-[minmax(220px,1fr)_180px] gap-2 rounded-[12px] border border-primary/[0.09] bg-white p-2 shadow-[0_1px_3px_rgba(13,24,41,0.03)]">
@@ -234,6 +265,10 @@ export function WebMovimientosWorkspace({
       </div>
 
       <div className="web-mov-layout">
+        {selectedRow && (
+          <MovementDetail row={selectedRow} hidden={hidden} onClose={() => setSelection({ key: requestKey, id: null })} />
+        )}
+
         <main data-web-movement-ledger="true" className="web-mov-ledger min-w-0 overflow-hidden rounded-[14px] border border-primary/[0.09] bg-white shadow-[0_1px_4px_rgba(13,24,41,0.04)]">
           <div className="flex items-center justify-between gap-4 border-b border-primary/[0.08] px-5 py-3">
             <div className="min-w-0">
@@ -261,7 +296,7 @@ export function WebMovimientosWorkspace({
                     <button
                       key={row.id}
                       type="button"
-                      onClick={() => setSelectedRowId(row.id)}
+                      onClick={() => setSelection({ key: requestKey, id: row.id })}
                       className={`flex w-full items-center gap-3 border-b border-primary/[0.07] px-5 py-3 text-left transition-colors last:border-b-0 hover:bg-primary/[0.025] ${selected ? 'bg-primary/[0.055]' : 'bg-white'}`}
                     >
                       <RowIcon row={row} />
@@ -269,7 +304,7 @@ export function WebMovimientosWorkspace({
                         <span className="block truncate text-[13px] font-semibold text-text-primary">{row.title}</span>
                         <span className="mt-0.5 block truncate text-[11px] text-text-dim">{row.secondary}</span>
                       </span>
-                      <span className={`shrink-0 text-right text-[13px] font-bold tabular-nums ${row.tone === 'income' || row.tone === 'yield' ? 'text-success' : 'text-text-primary'}`}>{signedAmountLabel(row, hidden)}</span>
+                      <span className={`shrink-0 text-right text-[13px] font-bold tabular-nums ${row.tone === 'income' || row.tone === 'yield' ? 'text-success' : 'text-text-primary'}`}>{movementAmountLabel(row, hidden)}</span>
                       <CaretRight size={13} className="shrink-0 text-text-disabled" />
                     </button>
                   )
@@ -279,9 +314,7 @@ export function WebMovimientosWorkspace({
           )}
         </main>
 
-        {selectedRow ? (
-          <MovementDetail row={selectedRow} hidden={hidden} onClose={() => setSelectedRowId(null)} />
-        ) : (
+        {!selectedRow && (
           <aside data-web-account-context="true" className="web-mov-context web-account-rail rounded-[14px] border border-primary/[0.09] bg-white p-3 shadow-[0_1px_4px_rgba(13,24,41,0.04)]">
             <div className="web-mov-context-heading flex items-center justify-between px-2 pb-2 pt-1">
               <div>

--- a/components/settings/CuentasSubSheet.tsx
+++ b/components/settings/CuentasSubSheet.tsx
@@ -10,11 +10,12 @@ import type { Account, AccountType } from '@/types/database'
 interface Props {
   open: boolean
   onClose: () => void
+  onChanged?: () => void
 }
 
 const TYPE_LABEL: Record<string, string> = { bank: 'Banco', digital: 'Digital', cash: 'Efectivo' }
 
-export function CuentasSubSheet({ open, onClose }: Props) {
+export function CuentasSubSheet({ open, onClose, onChanged }: Props) {
   const [accounts, setAccounts] = useState<Account[]>([])
   const [editing, setEditing] = useState<Account | null | undefined>(undefined)
   const [creatingType, setCreatingType] = useState<AccountType>('bank')
@@ -43,10 +44,12 @@ export function CuentasSubSheet({ open, onClose }: Props) {
       }
       return [...prev, saved]
     })
+    onChanged?.()
   }
 
   const handleDeleted = (id: string) => {
     setAccounts((prev) => prev.filter((a) => a.id !== id))
+    onChanged?.()
   }
 
   return (

--- a/components/web/dashboard/WebDashboardRoute.tsx
+++ b/components/web/dashboard/WebDashboardRoute.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import type { AnalyticsApiData } from '@/components/analytics/AnalyticsDataLoader'
@@ -44,7 +44,7 @@ export function WebDashboardRoute({
   initialView,
 }: Props) {
   const router = useRouter()
-  const [webNav, setWebNav] = useState<NavId>(initialView)
+  const webNav = initialView
   const analyticsQuery = useQuery<AnalyticsApiData>({
     queryKey: ['analytics', selectedMonth, viewCurrency, 'web'],
     queryFn: async () => {
@@ -81,7 +81,6 @@ export function WebDashboardRoute({
   }, [analyticsQuery.data, initialData.isCurrentMonth, selectedMonth])
 
   const navigateWeb = (nav: NavId, month = selectedMonth) => {
-    setWebNav(nav)
     router.push(buildWebNavHref(nav, { month, currency: viewCurrency }))
   }
 
@@ -152,8 +151,10 @@ export function WebDashboardRoute({
       availableBreakdown={initialData.availableBreakdown}
       quote={initialQuote}
       amountsVisible
-      onOpenSettings={() => router.push('/settings')}
-      onSelectMonth={(month) => router.push(`/web?month=${month}&currency=${viewCurrency}`)}
+      initialNav={webNav}
+      onNavChange={navigateWeb}
+      onOpenSettings={() => router.push('/web/settings')}
+      onSelectMonth={(month) => navigateWeb(webNav, month)}
     />
   )
 }

--- a/components/web/settings/WebSettingsPage.tsx
+++ b/components/web/settings/WebSettingsPage.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import {
   Bank,
   CaretRight,
@@ -13,6 +14,7 @@ import {
   Wallet,
 } from '@phosphor-icons/react'
 import { PasskeysPanel } from '@/components/auth/PasskeysPanel'
+import { CuentasSubSheet } from '@/components/settings/CuentasSubSheet'
 import type { Account, Card, HeroBalanceMode } from '@/types/database'
 
 type Props = {
@@ -73,10 +75,12 @@ export function WebSettingsPage({
   accounts,
   cards,
 }: Props) {
+  const router = useRouter()
   const [currency, setCurrency] = useState<'ARS' | 'USD'>(initialCurrency)
   const [heroBalanceMode, setHeroBalanceMode] = useState<HeroBalanceMode>(initialHeroBalanceMode)
   const [isSavingConfig, setIsSavingConfig] = useState(false)
   const [configMessage, setConfigMessage] = useState<string | null>(null)
+  const [accountsOpen, setAccountsOpen] = useState(false)
   const hasGoogle = authProviders.includes('google')
   const hasEmailProvider = authProviders.includes('email')
 
@@ -244,6 +248,14 @@ export function WebSettingsPage({
             description="Base operativa de la lectura de caja y saldo vivo."
           >
             <div className="space-y-3">
+              <button
+                type="button"
+                onClick={() => setAccountsOpen(true)}
+                className="flex w-full items-center justify-between rounded-2xl bg-primary-soft px-4 py-3 text-left text-[14px] font-semibold text-primary transition-colors hover:bg-primary/10"
+              >
+                Administrar cuentas
+                <CaretRight size={14} weight="bold" />
+              </button>
               {accounts.map((account) => (
                 <div key={account.id} className="flex items-center justify-between gap-4 rounded-2xl border border-border-subtle px-4 py-4">
                   <div className="flex min-w-0 items-center gap-3">
@@ -294,6 +306,11 @@ export function WebSettingsPage({
           </SectionFrame>
         </div>
       </div>
+      <CuentasSubSheet
+        open={accountsOpen}
+        onClose={() => setAccountsOpen(false)}
+        onChanged={() => router.refresh()}
+      />
     </div>
   )
 }

--- a/lib/home-plus-expense-flow.test.ts
+++ b/lib/home-plus-expense-flow.test.ts
@@ -1,0 +1,39 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { HOME_PLUS_EXPENSE_LABEL } from '@/components/dashboard/HomePlusButton'
+import { ParsePreview } from '@/components/dashboard/ParsePreview'
+
+const parsedExpense = {
+  amount: 24_500,
+  currency: 'ARS' as const,
+  category: 'Alimentos',
+  description: 'Supermercado',
+  is_want: false,
+  is_recurring: false,
+  is_extraordinary: false,
+  payment_method: 'DEBIT' as const,
+  card_id: null,
+  installments: null,
+  date: '2026-07-23T12:00:00-03:00',
+}
+
+describe('HomePlus expense flow', () => {
+  it('uses the exact common-expense label', () => {
+    expect(HOME_PLUS_EXPENSE_LABEL).toBe('Gasto común')
+  })
+
+  it('can render ParsePreview inline under a single modal owner', () => {
+    const html = renderToStaticMarkup(createElement(ParsePreview, {
+      data: parsedExpense,
+      cards: [],
+      accounts: [],
+      onSave: () => undefined,
+      onCancel: () => undefined,
+      embedded: true,
+    }))
+
+    expect(html).toContain('data-parse-preview-inline="true"')
+    expect(html).toContain('Confirmar gasto')
+  })
+})

--- a/lib/movimientos-pagination.test.ts
+++ b/lib/movimientos-pagination.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { paginateMovements, type PaginatedMovement } from './movimientos-pagination'
+
+function expense(id: string): PaginatedMovement {
+  return {
+    kind: 'expense',
+    data: {
+      id,
+      date: '2026-07-20',
+      created_at: `2026-07-20T12:${id.padStart(2, '0')}:00.000Z`,
+    },
+  } as PaginatedMovement
+}
+
+describe('paginateMovements', () => {
+  it('keeps yield rows in the same stable collection on every page', () => {
+    const regular = Array.from({ length: 25 }, (_, index) => expense(String(index + 1)))
+    const yieldMovement = {
+      kind: 'yield',
+      data: { id: 'yield-1', date: '2026-07-20' },
+    } as PaginatedMovement
+
+    const page1 = paginateMovements([yieldMovement, ...regular], 1, 20, '2026-07-23')
+    const page2 = paginateMovements([yieldMovement, ...regular], 2, 20, '2026-07-23')
+    const combinedIds = [...page1.movements, ...page2.movements].map((movement) => movement.data.id)
+
+    expect(page1.total).toBe(26)
+    expect(page2.total).toBe(26)
+    expect(combinedIds).toHaveLength(26)
+    expect(new Set(combinedIds).size).toBe(26)
+    expect(combinedIds).toEqual(expect.arrayContaining(['yield-1', ...regular.map((movement) => movement.data.id)]))
+  })
+})

--- a/lib/movimientos-pagination.ts
+++ b/lib/movimientos-pagination.ts
@@ -1,0 +1,34 @@
+import { toDateOnly } from '@/lib/format'
+import type { YieldMonthlyMovementData } from '@/lib/movimientos-yield'
+import type { Expense, IncomeEntry, Transfer } from '@/types/database'
+
+export type PaginatedMovement =
+  | { kind: 'expense'; data: Expense }
+  | { kind: 'income'; data: IncomeEntry }
+  | { kind: 'transfer'; data: Transfer }
+  | { kind: 'yield'; data: YieldMonthlyMovementData }
+
+export function paginateMovements(
+  movements: PaginatedMovement[],
+  page: number,
+  pageSize: number,
+  today: string,
+): { movements: PaginatedMovement[]; total: number } {
+  const sorted = [...movements].sort((a, b) => {
+    const dateA = toDateOnly(a.data.date)
+    const dateB = toDateOnly(b.data.date)
+    const aFuture = dateA > today
+    const bFuture = dateB > today
+    if (aFuture !== bFuture) return aFuture ? 1 : -1
+    if (dateB !== dateA) return dateB.localeCompare(dateA)
+    const createdAtA = a.kind === 'yield' ? '' : a.data.created_at
+    const createdAtB = b.kind === 'yield' ? '' : b.data.created_at
+    return createdAtB.localeCompare(createdAtA)
+  })
+  const offset = (page - 1) * pageSize
+
+  return {
+    movements: sorted.slice(offset, offset + pageSize),
+    total: sorted.length,
+  }
+}

--- a/lib/web-dashboard-route-navigation.test.ts
+++ b/lib/web-dashboard-route-navigation.test.ts
@@ -1,0 +1,43 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: undefined, isLoading: false, isError: false }),
+}))
+
+vi.mock('@/lib/flags', () => ({ FF_WEB_PANEL_BRIEF_V1: false }))
+
+vi.mock('@/components/dashboard/desktop/DesktopDashboardShell', () => ({
+  DesktopDashboardShell: (props: { initialNav?: string; onNavChange?: unknown }) =>
+    createElement('div', {
+      'data-initial-nav': props.initialNav ?? 'missing',
+      'data-has-nav-change': typeof props.onNavChange === 'function' ? 'true' : 'false',
+    }),
+}))
+
+vi.mock('@/components/dashboard/web-panel/WebPanelBriefV1', () => ({
+  WebPanelBriefV1: () => createElement('div'),
+}))
+
+import { WebDashboardRoute } from '@/components/web/dashboard/WebDashboardRoute'
+
+describe('WebDashboardRoute flag-off navigation', () => {
+  it('preserves the URL-selected desktop view and URL-aware navigation callback', () => {
+    const html = renderToStaticMarkup(createElement(WebDashboardRoute, {
+      selectedMonth: '2026-07',
+      viewCurrency: 'ARS',
+      userEmail: 'facu@example.com',
+      initialData: { isCurrentMonth: true } as never,
+      initialQuote: null,
+      initialView: 'movimientos',
+    }))
+
+    expect(html).toContain('data-initial-nav="movimientos"')
+    expect(html).toContain('data-has-nav-change="true"')
+  })
+})

--- a/lib/web-movimientos-resource.test.ts
+++ b/lib/web-movimientos-resource.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveMovementsResource,
+  resolveSelectedMovementId,
+  type MovementsResource,
+} from './web-movimientos-resource'
+import type { ApiMovement } from '@/components/dashboard/desktop/movimientos-data'
+
+const previous = [{ kind: 'expense', data: { id: 'old' } }] as ApiMovement[]
+
+describe('resolveMovementsResource', () => {
+  it('does not expose movements from a previous month while the next month loads', () => {
+    const resource: MovementsResource = {
+      key: '2026-06:0',
+      movements: previous,
+      failed: false,
+    }
+
+    expect(resolveMovementsResource(resource, '2026-07:0')).toEqual({
+      movements: [],
+      loading: true,
+      failed: false,
+    })
+  })
+
+  it('exposes only the response matching the current request key', () => {
+    const resource: MovementsResource = {
+      key: '2026-07:1',
+      movements: previous,
+      failed: false,
+    }
+
+    expect(resolveMovementsResource(resource, '2026-07:1')).toEqual({
+      movements: previous,
+      loading: false,
+      failed: false,
+    })
+  })
+
+  it('does not reopen a selection from a previous request key', () => {
+    expect(resolveSelectedMovementId(
+      { key: '2026-06:0', id: 'expense:old' },
+      '2026-07:0',
+    )).toBeNull()
+    expect(resolveSelectedMovementId(
+      { key: '2026-07:0', id: 'expense:current' },
+      '2026-07:0',
+    )).toBe('expense:current')
+  })
+})

--- a/lib/web-movimientos-resource.ts
+++ b/lib/web-movimientos-resource.ts
@@ -1,0 +1,34 @@
+import type { ApiMovement } from '@/components/dashboard/desktop/movimientos-data'
+
+export type MovementsResource = {
+  key: string
+  movements: ApiMovement[]
+  failed: boolean
+}
+
+export type MovementSelection = {
+  key: string
+  id: string | null
+}
+
+export function resolveSelectedMovementId(
+  selection: MovementSelection,
+  requestKey: string,
+): string | null {
+  return selection.key === requestKey ? selection.id : null
+}
+
+export function resolveMovementsResource(
+  resource: MovementsResource,
+  requestKey: string,
+): { movements: ApiMovement[]; loading: boolean; failed: boolean } {
+  if (resource.key !== requestKey) {
+    return { movements: [], loading: true, failed: false }
+  }
+
+  return {
+    movements: resource.movements,
+    loading: false,
+    failed: resource.failed,
+  }
+}

--- a/lib/web-movimientos-workspace.test.ts
+++ b/lib/web-movimientos-workspace.test.ts
@@ -3,7 +3,8 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import type { Account, Card } from '@/types/database'
 import type { ApiMovement } from '@/components/dashboard/desktop/movimientos-data'
-import { WebMovimientosWorkspace } from '@/components/dashboard/desktop/WebMovimientosWorkspace'
+import { MovementDetail, WebMovimientosWorkspace } from '@/components/dashboard/desktop/WebMovimientosWorkspace'
+import { buildWebMovementRows } from './web-movimientos-model'
 
 const accounts = [
   { id: 'nacion', name: 'Nación', type: 'bank', is_primary: true },
@@ -24,6 +25,20 @@ const movements = [
       card_id: null,
       date: '2026-07-23',
       created_at: '2026-07-23T12:00:00Z',
+    },
+  },
+  {
+    kind: 'transfer',
+    data: {
+      id: 'transfer-fx',
+      from_account_id: 'mp',
+      to_account_id: 'nacion',
+      amount_from: 100,
+      amount_to: 150_000,
+      currency_from: 'USD',
+      currency_to: 'ARS',
+      date: '2026-07-23',
+      created_at: '2026-07-23T11:00:00Z',
     },
   },
 ] as ApiMovement[]
@@ -54,8 +69,24 @@ describe('WebMovimientosWorkspace', () => {
     expect(html).toContain('Todas las cuentas')
     expect(html).toContain('Carrefour')
     expect(html).toContain('Alimentos · Nación')
+    expect(html).toContain('USD 100,00 → $ 150.000')
     expect(html).toContain('Nuevo movimiento')
     expect(html).not.toContain('Gastos del mes')
     expect(html).not.toContain('Margen')
+  })
+
+  it('marks movement detail so narrow layouts can place it before the ledger', () => {
+    const transfer = buildWebMovementRows([movements[1]], accounts, [])[0]
+    const html = renderToStaticMarkup(
+      createElement(MovementDetail, {
+        row: transfer,
+        hidden: false,
+        onClose: () => undefined,
+      }),
+    )
+
+    expect(html).toContain('data-web-movement-detail="true"')
+    expect(html).toContain('web-movement-detail')
+    expect(html).toContain('USD 100,00 → $ 150.000')
   })
 })

--- a/lib/web-settings-account-management.test.ts
+++ b/lib/web-settings-account-management.test.ts
@@ -1,0 +1,30 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn() }) }))
+vi.mock('@/components/auth/PasskeysPanel', () => ({ PasskeysPanel: () => createElement('div') }))
+vi.mock('@/components/settings/CuentasSubSheet', () => ({
+  CuentasSubSheet: ({ onChanged }: { onChanged?: () => void }) => createElement('div', {
+    'data-account-invalidation': typeof onChanged === 'function' ? 'wired' : 'missing',
+  }),
+}))
+
+import { WebSettingsPage } from '@/components/web/settings/WebSettingsPage'
+
+describe('WebSettingsPage account management', () => {
+  it('exposes the mature account-management flow from Web settings', () => {
+    const html = renderToStaticMarkup(createElement(WebSettingsPage, {
+      email: 'facu@example.com',
+      isAnonymous: false,
+      authProviders: ['email'],
+      currency: 'ARS',
+      heroBalanceMode: 'combined_ars',
+      accounts: [],
+      cards: [],
+    }))
+
+    expect(html).toContain('Administrar cuentas')
+    expect(html).toContain('data-account-invalidation="wired"')
+  })
+})


### PR DESCRIPTION
## Resumen
- corrige navegación URL/history y aislamiento por período del workspace Movimientos
- pagina movimientos y rendimientos como una colección estable
- conecta recargas sólo después de mutaciones exitosas y evita modales anidados
- muestra transferencias bimoneda y mejora detalle responsive
- integra gestión de cuentas en Settings con refresh

## Verificación
- 74 archivos / 497 tests passing
- TypeScript passing
- ESLint passing
- Next.js build passing
- revisión independiente: PASS / APPROVED