### PR TITLE
feat(device): read-only Gota snapshot for ESP32

### DIFF
--- a/app/api/device/v1/snapshot/route.ts
+++ b/app/api/device/v1/snapshot/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server'
+import { authorizeDeviceToken, type DeviceTokenRecord } from '@/lib/device-auth/device-token'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { getCurrentMonth } from '@/lib/dates'
+import { readDashboardData } from '@/lib/server/dashboard-queries'
+import { loadFinancialSnapshot } from '@/lib/intelligence/snapshot'
+import { buildDeviceSnapshot } from '@/lib/device-snapshot/build-device-snapshot'
+import { createDeviceSnapshotResponse } from '@/lib/device-snapshot/handle-device-snapshot'
+
+export const dynamic = 'force-dynamic'
+
+async function findActiveDeviceToken(tokenHash: string): Promise<DeviceTokenRecord | null> {
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from('device_access_tokens')
+    .select('id, user_id, label, token_hash, scopes, revoked_at')
+    .eq('token_hash', tokenHash)
+    .is('revoked_at', null)
+    .maybeSingle()
+
+  if (error) throw error
+  if (!data) return null
+
+  return {
+    id: data.id,
+    userId: data.user_id,
+    label: data.label,
+    tokenHash: data.token_hash,
+    scopes: data.scopes,
+    revokedAt: data.revoked_at,
+  }
+}
+
+export async function GET(request: Request) {
+  const response = await createDeviceSnapshotResponse({
+    authorization: request.headers.get('authorization'),
+    authorize: (authorization) => authorizeDeviceToken(authorization, findActiveDeviceToken),
+    loadSnapshot: async (device) => {
+      const admin = createAdminClient()
+      const month = getCurrentMonth()
+      const dashboard = await readDashboardData({
+        supabase: admin,
+        userId: device.userId,
+        selectedMonth: month,
+        viewCurrency: 'ARS',
+      })
+      const financialSnapshot = await loadFinancialSnapshot({
+        supabase: admin,
+        userId: device.userId,
+        month,
+        dashboard,
+      })
+      return buildDeviceSnapshot({ dashboard, financialSnapshot })
+    },
+  })
+
+  return NextResponse.json(response.body, {
+    status: response.status,
+    headers: response.headers,
+  })
+}

--- a/app/api/device/v1/snapshot/route.ts
+++ b/app/api/device/v1/snapshot/route.ts
@@ -13,7 +13,7 @@ async function findActiveDeviceToken(tokenHash: string): Promise<DeviceTokenReco
   const admin = createAdminClient()
   const { data, error } = await admin
     .from('device_access_tokens')
-    .select('id, user_id, label, token_hash, scopes, revoked_at')
+    .select('id, user_id, label, token_hash, scopes, revoked_at, expires_at')
     .eq('token_hash', tokenHash)
     .is('revoked_at', null)
     .maybeSingle()
@@ -28,6 +28,7 @@ async function findActiveDeviceToken(tokenHash: string): Promise<DeviceTokenReco
     tokenHash: data.token_hash,
     scopes: data.scopes,
     revokedAt: data.revoked_at,
+    expiresAt: data.expires_at,
   }
 }
 
@@ -48,6 +49,7 @@ export async function GET(request: Request) {
         supabase: admin,
         userId: device.userId,
         month,
+        currency: dashboard.viewCurrency,
         dashboard,
       })
       return buildDeviceSnapshot({ dashboard, financialSnapshot })

--- a/docs/supabase-device-access-tokens.sql
+++ b/docs/supabase-device-access-tokens.sql
@@ -9,6 +9,7 @@ create table if not exists public.device_access_tokens (
   token_hash text not null unique check (char_length(token_hash) = 64),
   scopes text[] not null default array['dashboard:read']::text[],
   created_at timestamptz not null default now(),
+  expires_at timestamptz not null,
   last_seen_at timestamptz,
   revoked_at timestamptz,
   revoked_reason text

--- a/docs/supabase-device-access-tokens.sql
+++ b/docs/supabase-device-access-tokens.sql
@@ -1,0 +1,25 @@
+-- Gota — ESP32 device read access
+-- Apply once in the intended Supabase project through the SQL Editor.
+-- This migration is additive and does not expose device credentials to browser clients.
+
+create table if not exists public.device_access_tokens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  label text not null check (char_length(label) between 1 and 120),
+  token_hash text not null unique check (char_length(token_hash) = 64),
+  scopes text[] not null default array['dashboard:read']::text[],
+  created_at timestamptz not null default now(),
+  last_seen_at timestamptz,
+  revoked_at timestamptz,
+  revoked_reason text
+);
+
+create index if not exists device_access_tokens_active_hash_idx
+  on public.device_access_tokens (token_hash)
+  where revoked_at is null;
+
+alter table public.device_access_tokens enable row level security;
+
+-- No authenticated-browser policies are added. Server-side Gota routes use the
+-- service-role client after validating a bearer device token. Raw tokens are
+-- generated outside this migration and only their SHA-256 hashes are stored.

--- a/lib/device-auth/device-token.test.ts
+++ b/lib/device-auth/device-token.test.ts
@@ -15,6 +15,7 @@ describe('authorizeDeviceToken', () => {
         tokenHash,
         scopes: ['dashboard:read'],
         revokedAt: null,
+        expiresAt: null,
       }
     })
 
@@ -28,5 +29,22 @@ describe('authorizeDeviceToken', () => {
       },
     })
     expect(JSON.stringify(result)).not.toContain(tokenHash)
+  })
+
+  it('rechaza un token vencido aunque conserve el scope', async () => {
+    const rawToken = 'gota_dev_expired_token_for_unit_test'
+    const tokenHash = hashDeviceToken(rawToken)
+
+    const result = await authorizeDeviceToken(`Bearer ${rawToken}`, async () => ({
+      id: 'device-expired',
+      userId: 'user-1',
+      label: 'ESP32 escritorio',
+      tokenHash,
+      scopes: ['dashboard:read'],
+      revokedAt: null,
+      expiresAt: '2026-01-01T00:00:00.000Z',
+    }))
+
+    expect(result).toEqual({ kind: 'unauthorized' })
   })
 })

--- a/lib/device-auth/device-token.test.ts
+++ b/lib/device-auth/device-token.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { authorizeDeviceToken, hashDeviceToken } from './device-token'
+
+describe('authorizeDeviceToken', () => {
+  it('autoriza un bearer token activo con scope dashboard:read sin exponer hash', async () => {
+    const rawToken = 'gota_dev_test_token_for_unit_test'
+    const tokenHash = hashDeviceToken(rawToken)
+
+    const result = await authorizeDeviceToken(`Bearer ${rawToken}`, async (hash) => {
+      expect(hash).toBe(tokenHash)
+      return {
+        id: 'device-1',
+        userId: 'user-1',
+        label: 'ESP32 escritorio',
+        tokenHash,
+        scopes: ['dashboard:read'],
+        revokedAt: null,
+      }
+    })
+
+    expect(result).toEqual({
+      kind: 'authorized',
+      device: {
+        id: 'device-1',
+        userId: 'user-1',
+        label: 'ESP32 escritorio',
+        scopes: ['dashboard:read'],
+      },
+    })
+    expect(JSON.stringify(result)).not.toContain(tokenHash)
+  })
+})

--- a/lib/device-auth/device-token.ts
+++ b/lib/device-auth/device-token.ts
@@ -1,0 +1,53 @@
+import { createHash } from 'node:crypto'
+
+const REQUIRED_SCOPE = 'dashboard:read'
+
+export type DeviceTokenRecord = {
+  id: string
+  userId: string
+  label: string
+  tokenHash: string
+  scopes: string[]
+  revokedAt: string | null
+}
+
+export type AuthorizedDevice = Pick<DeviceTokenRecord, 'id' | 'userId' | 'label' | 'scopes'>
+
+export type DeviceAuthorizationResult =
+  | { kind: 'authorized'; device: AuthorizedDevice }
+  | { kind: 'unauthorized' }
+
+export type FindDeviceToken = (tokenHash: string) => Promise<DeviceTokenRecord | null>
+
+export function hashDeviceToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex')
+}
+
+function parseBearerToken(authorization: string | null): string | null {
+  if (!authorization) return null
+  const match = /^Bearer ([^\s]+)$/i.exec(authorization.trim())
+  return match?.[1] ?? null
+}
+
+export async function authorizeDeviceToken(
+  authorization: string | null,
+  findDeviceToken: FindDeviceToken,
+): Promise<DeviceAuthorizationResult> {
+  const rawToken = parseBearerToken(authorization)
+  if (!rawToken) return { kind: 'unauthorized' }
+
+  const record = await findDeviceToken(hashDeviceToken(rawToken))
+  if (!record || record.revokedAt || !record.scopes.includes(REQUIRED_SCOPE)) {
+    return { kind: 'unauthorized' }
+  }
+
+  return {
+    kind: 'authorized',
+    device: {
+      id: record.id,
+      userId: record.userId,
+      label: record.label,
+      scopes: record.scopes,
+    },
+  }
+}

--- a/lib/device-auth/device-token.ts
+++ b/lib/device-auth/device-token.ts
@@ -9,6 +9,7 @@ export type DeviceTokenRecord = {
   tokenHash: string
   scopes: string[]
   revokedAt: string | null
+  expiresAt: string | null
 }
 
 export type AuthorizedDevice = Pick<DeviceTokenRecord, 'id' | 'userId' | 'label' | 'scopes'>
@@ -37,7 +38,13 @@ export async function authorizeDeviceToken(
   if (!rawToken) return { kind: 'unauthorized' }
 
   const record = await findDeviceToken(hashDeviceToken(rawToken))
-  if (!record || record.revokedAt || !record.scopes.includes(REQUIRED_SCOPE)) {
+  const expiresAt = record?.expiresAt ? new Date(record.expiresAt).getTime() : null
+  if (
+    !record ||
+    record.revokedAt ||
+    !record.scopes.includes(REQUIRED_SCOPE) ||
+    (expiresAt !== null && (!Number.isFinite(expiresAt) || expiresAt <= Date.now()))
+  ) {
     return { kind: 'unauthorized' }
   }
 

--- a/lib/device-snapshot/build-device-snapshot.test.ts
+++ b/lib/device-snapshot/build-device-snapshot.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { buildDeviceSnapshot } from './build-device-snapshot'
+import { makeSnapshot } from '@/lib/intelligence/__tests__/fixtures'
+import type { DashboardApiData } from '@/lib/server/dashboard-queries'
+
+function dashboardFixture(overrides: Partial<DashboardApiData> = {}): DashboardApiData {
+  return {
+    dashboardData: null,
+    heroBalanceMode: 'combined_ars',
+    heroBreakdown: { ARS: 1_250_000, USD: 0 },
+    availableBreakdown: { ARS: 890_000, USD: 0 },
+    goalCommitmentsBreakdown: { ARS: 130_000, USD: 0 },
+    freeBreakdown: { ARS: 760_000, USD: 0 },
+    accounts: [],
+    cards: [],
+    currency: 'ARS',
+    viewCurrency: 'ARS',
+    hasIncomeAfterRollover: true,
+    autoRolloverAmount: null,
+    manualRolloverSummary: null,
+    activeSubscriptions: [],
+    allUltimos: [],
+    incomeEntries: [],
+    transfers: [],
+    transferCurrencyAdjustment: 0,
+    earliestDataMonth: '2026-02',
+    hasUsdExpenses: false,
+    selectedMonth: '2026-07',
+    isCurrentMonth: true,
+    isProjected: false,
+    yieldAccumulators: [],
+    activeInstruments: [],
+    capitalInstrumentosMes: 0,
+    recurringPending: [],
+    activeRecurring: [],
+    compromisos: {
+      mode: 'current',
+      totalDebt: 92_000,
+      pctComprometido: null,
+      ingresoMes: null,
+      tarjetas: [
+        {
+          id: 'visa',
+          name: 'Visa',
+          closingDay: 14,
+          dueDay: 20,
+          currentSpend: 184_000,
+          daysUntilClosing: 3,
+          debtTotal: 0,
+          debtCycles: [],
+          cycleStatus: 'en_curso',
+          dueDate: null,
+          daysUntilDue: null,
+          amountPaid: null,
+          paidAt: null,
+          pendingSubs: [],
+        },
+        {
+          id: 'mastercard',
+          name: 'Mastercard',
+          closingDay: 8,
+          dueDay: 18,
+          currentSpend: 0,
+          daysUntilClosing: null,
+          debtTotal: 92_000,
+          debtCycles: [{ periodMonth: '2026-06', amount: 92_000, dueDate: '2026-07-18', cycleStatus: 'cerrado' }],
+          cycleStatus: 'cerrado',
+          dueDate: '2026-07-18',
+          daysUntilDue: 4,
+          amountPaid: null,
+          paidAt: null,
+          pendingSubs: [],
+        },
+      ],
+      tarjetasSinVencimiento: [],
+      hasCards: true,
+      hasCreditExpenses: true,
+      totalComprometido: 276_000,
+      unassignedCreditSpend: 0,
+      totalAPagar: 92_000,
+      totalEnCurso: 184_000,
+    },
+    accountBalances: [],
+    cardPaymentPrompts: [],
+    goals: [],
+    ...overrides,
+  }
+}
+
+describe('buildDeviceSnapshot', () => {
+  it('construye un snapshot mínimo con balances canónicos, tarjetas priorizadas y ritmo same-day', () => {
+    const result = buildDeviceSnapshot({
+      dashboard: dashboardFixture(),
+      financialSnapshot: makeSnapshot(),
+      now: new Date('2026-07-15T15:00:00.000Z'),
+    })
+
+    expect(result).toMatchObject({
+      schema_version: 1,
+      currency: 'ARS',
+      balances: {
+        saldo_vivo: 1_250_000,
+        disponible_real: 890_000,
+        libre_hoy: 760_000,
+        card_commitments: 360_000,
+      },
+      cards: [
+        { id: 'mastercard', cycle_status: 'cerrado', debt_total: 92_000 },
+        { id: 'visa', cycle_status: 'en_curso', current_spend: 184_000 },
+      ],
+      pace: {
+        available: true,
+        current_amount: 140_000,
+        baseline_amount: 140_000,
+        baseline_kind: 'rolling_average',
+        baseline_window: 5,
+        baseline_label: 'vs. promedio de 5 meses al día 15',
+        delta_percent: 0,
+      },
+    })
+    expect(result.as_of).toBe('2026-07-15T15:00:00.000Z')
+  })
+})

--- a/lib/device-snapshot/build-device-snapshot.ts
+++ b/lib/device-snapshot/build-device-snapshot.ts
@@ -1,0 +1,115 @@
+import { computeSameDaySpend } from '@/lib/intelligence/features'
+import type { FinancialSnapshot } from '@/lib/intelligence/types'
+import type { DashboardApiData } from '@/lib/server/dashboard-queries'
+
+export type DeviceSnapshot = {
+  schema_version: 1
+  as_of: string
+  currency: 'ARS' | 'USD'
+  balances: {
+    saldo_vivo: number
+    disponible_real: number
+    libre_hoy: number
+    card_commitments: number
+  }
+  cards: Array<{
+    id: string
+    name: string
+    current_spend: number
+    debt_total: number
+    days_until_closing: number | null
+    due_date: string | null
+    days_until_due: number | null
+    cycle_status: 'en_curso' | 'cerrado' | 'vencido' | 'pagado'
+  }>
+  pace: {
+    available: boolean
+    current_amount: number
+    baseline_amount: number | null
+    baseline_kind: 'previous_month' | 'rolling_average' | null
+    baseline_window: number
+    baseline_label: string | null
+    delta_percent: number | null
+  }
+}
+
+function assertFiniteAmount(value: number, field: string): number {
+  if (!Number.isFinite(value)) throw new Error(`Invalid device snapshot amount: ${field}`)
+  return value
+}
+
+function cardPriority(status: DeviceSnapshot['cards'][number]['cycle_status']): number {
+  return { vencido: 0, cerrado: 1, en_curso: 2, pagado: 3 }[status]
+}
+
+function spanishMonth(month: string): string {
+  const date = new Date(`${month}-15T12:00:00.000Z`)
+  return new Intl.DateTimeFormat('es-AR', { month: 'long', timeZone: 'UTC' }).format(date)
+}
+
+function paceLabel(feature: ReturnType<typeof computeSameDaySpend>, snapshot: FinancialSnapshot): string | null {
+  if (!feature.baselineKind) return null
+  if (feature.baselineKind === 'previous_month') {
+    const [year, month] = snapshot.month.split('-').map(Number)
+    const previousMonth = `${month === 1 ? year - 1 : year}-${String(month === 1 ? 12 : month - 1).padStart(2, '0')}`
+    return `vs. ${spanishMonth(previousMonth)} al día ${snapshot.dayOfMonth}`
+  }
+  return `vs. promedio de ${feature.baselineWindow} meses al día ${snapshot.dayOfMonth}`
+}
+
+export function buildDeviceSnapshot(params: {
+  dashboard: DashboardApiData
+  financialSnapshot: FinancialSnapshot
+  now?: Date
+}): DeviceSnapshot {
+  const { dashboard, financialSnapshot, now = new Date() } = params
+  const currency = dashboard.viewCurrency
+  const saldoVivo = assertFiniteAmount(dashboard.heroBreakdown[currency], 'saldo_vivo')
+  const disponibleReal = assertFiniteAmount(dashboard.availableBreakdown[currency], 'disponible_real')
+  const libreHoy = assertFiniteAmount(dashboard.freeBreakdown[currency], 'libre_hoy')
+  const cardCommitments = assertFiniteAmount(saldoVivo - disponibleReal, 'card_commitments')
+
+  const cards = (dashboard.compromisos?.tarjetas ?? [])
+    .filter((card) => card.currentSpend > 0 || card.debtTotal > 0)
+    .map((card) => ({
+      id: card.id,
+      name: card.name,
+      current_spend: assertFiniteAmount(card.currentSpend, 'card.current_spend'),
+      debt_total: assertFiniteAmount(card.debtTotal, 'card.debt_total'),
+      days_until_closing: card.daysUntilClosing,
+      due_date: card.dueDate,
+      days_until_due: card.daysUntilDue,
+      cycle_status: card.cycleStatus ?? 'en_curso',
+    }))
+    .sort((left, right) => {
+      const byStatus = cardPriority(left.cycle_status) - cardPriority(right.cycle_status)
+      if (byStatus !== 0) return byStatus
+      return right.debt_total + right.current_spend - (left.debt_total + left.current_spend)
+    })
+    .slice(0, 2)
+
+  const feature = computeSameDaySpend(financialSnapshot)
+  const paceAvailable = feature.dataQuality !== 'insufficient' && feature.baselineAmount !== null
+
+  return {
+    schema_version: 1,
+    as_of: now.toISOString(),
+    currency,
+    balances: {
+      saldo_vivo: saldoVivo,
+      disponible_real: disponibleReal,
+      libre_hoy: libreHoy,
+      card_commitments: cardCommitments,
+    },
+    cards,
+    pace: {
+      available: paceAvailable,
+      current_amount: assertFiniteAmount(feature.currentAmount, 'pace.current_amount'),
+      baseline_amount: paceAvailable ? assertFiniteAmount(feature.baselineAmount as number, 'pace.baseline_amount') : null,
+      baseline_kind: paceAvailable ? feature.baselineKind : null,
+      baseline_window: paceAvailable ? feature.baselineWindow : 0,
+      baseline_label: paceAvailable ? paceLabel(feature, financialSnapshot) : null,
+      delta_percent: paceAvailable ? feature.deltaPct : null,
+    },
+  }
+}

--- a/lib/device-snapshot/handle-device-snapshot.test.ts
+++ b/lib/device-snapshot/handle-device-snapshot.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createDeviceSnapshotResponse } from './handle-device-snapshot'
+
+const device = {
+  id: 'device-1',
+  userId: 'user-1',
+  label: 'ESP32 escritorio',
+  scopes: ['dashboard:read'],
+}
+
+describe('createDeviceSnapshotResponse', () => {
+  it('rechaza un token inválido sin ejecutar el loader ni filtrar detalles', async () => {
+    const loadSnapshot = vi.fn()
+
+    const response = await createDeviceSnapshotResponse({
+      authorization: 'Bearer invalid-token',
+      authorize: async () => ({ kind: 'unauthorized' }),
+      loadSnapshot,
+    })
+
+    expect(response).toEqual({ status: 401, body: { error: 'unauthorized' } })
+    expect(loadSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('entrega un snapshot read-only con no-store para un dispositivo autorizado', async () => {
+    const response = await createDeviceSnapshotResponse({
+      authorization: 'Bearer valid-token',
+      authorize: async () => ({ kind: 'authorized', device }),
+      loadSnapshot: async (authorizedDevice) => {
+        expect(authorizedDevice).toEqual(device)
+        return { schema_version: 1, balances: { saldo_vivo: 1250000 } }
+      },
+    })
+
+    expect(response).toEqual({
+      status: 200,
+      body: { schema_version: 1, balances: { saldo_vivo: 1250000 } },
+      headers: { 'Cache-Control': 'private, no-store' },
+    })
+  })
+})

--- a/lib/device-snapshot/handle-device-snapshot.ts
+++ b/lib/device-snapshot/handle-device-snapshot.ts
@@ -1,0 +1,29 @@
+import type { AuthorizedDevice, DeviceAuthorizationResult } from '@/lib/device-auth/device-token'
+
+export type DeviceSnapshotResponse = {
+  status: number
+  body: unknown
+  headers?: Record<string, string>
+}
+
+export async function createDeviceSnapshotResponse(params: {
+  authorization: string | null
+  authorize: (authorization: string | null) => Promise<DeviceAuthorizationResult>
+  loadSnapshot: (device: AuthorizedDevice) => Promise<unknown>
+}): Promise<DeviceSnapshotResponse> {
+  const authorization = await params.authorize(params.authorization)
+  if (authorization.kind !== 'authorized') {
+    return { status: 401, body: { error: 'unauthorized' } }
+  }
+
+  try {
+    const snapshot = await params.loadSnapshot(authorization.device)
+    return {
+      status: 200,
+      body: snapshot,
+      headers: { 'Cache-Control': 'private, no-store' },
+    }
+  } catch {
+    return { status: 500, body: { error: 'unavailable' } }
+  }
+}

--- a/lib/intelligence/__tests__/snapshot-currency.test.ts
+++ b/lib/intelligence/__tests__/snapshot-currency.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSnapshotCurrency } from '../snapshot'
+
+describe('resolveSnapshotCurrency', () => {
+  it('prioriza la moneda solicitada por la superficie sobre la moneda default del dashboard', () => {
+    expect(
+      resolveSnapshotCurrency({
+        requestedCurrency: 'ARS',
+        dashboardCurrency: 'USD',
+      }),
+    ).toBe('ARS')
+  })
+})

--- a/lib/intelligence/snapshot.ts
+++ b/lib/intelligence/snapshot.ts
@@ -446,10 +446,19 @@ export async function fetchExpenseRows(options: {
  * Carga el snapshot desde Supabase reusando las queries existentes
  * (readDashboardData, getBudgetSnapshot) + histórico de movimientos.
  */
+export function resolveSnapshotCurrency(params: {
+  requestedCurrency?: Currency
+  dashboardCurrency?: Currency
+}): Currency {
+  return params.requestedCurrency ?? params.dashboardCurrency ?? 'ARS'
+}
+
 export async function loadFinancialSnapshot(params: {
   supabase: SupabaseClient
   userId: string
   month?: string
+  /** Fuerza la moneda de la superficie consumidora cuando difiere del default del usuario. */
+  currency?: Currency
   /** Dashboard ya resuelto: evita repetir sus queries (guía §19). */
   dashboard?: Awaited<ReturnType<typeof readDashboardData>>
 }): Promise<FinancialSnapshot> {
@@ -461,8 +470,11 @@ export async function loadFinancialSnapshot(params: {
   const futureHorizonDate = `${addMonths(month, FUTURE_INSTALLMENT_MONTHS + 1)}-01`
 
   let currency: Currency
-  if (params.dashboard) {
-    currency = params.dashboard.currency
+  if (params.dashboard || params.currency) {
+    currency = resolveSnapshotCurrency({
+      requestedCurrency: params.currency,
+      dashboardCurrency: params.dashboard?.currency,
+    })
   } else {
     const { data: config } = await supabase
       .from('user_config')

--- a/schema.sql
+++ b/schema.sql
@@ -21,6 +21,7 @@ CREATE TABLE device_access_tokens (
   token_hash TEXT NOT NULL UNIQUE CHECK (char_length(token_hash) = 64),
   scopes TEXT[] NOT NULL DEFAULT ARRAY['dashboard:read']::TEXT[],
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
   last_seen_at TIMESTAMPTZ,
   revoked_at TIMESTAMPTZ,
   revoked_reason TEXT

--- a/schema.sql
+++ b/schema.sql
@@ -11,6 +11,28 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE EXTENSION IF NOT EXISTS "pg_stat_statements";
 
 -- ============================================
+-- DEVICE ACCESS TOKENS (ESP32 read-only surface)
+-- ============================================
+
+CREATE TABLE device_access_tokens (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  label TEXT NOT NULL CHECK (char_length(label) BETWEEN 1 AND 120),
+  token_hash TEXT NOT NULL UNIQUE CHECK (char_length(token_hash) = 64),
+  scopes TEXT[] NOT NULL DEFAULT ARRAY['dashboard:read']::TEXT[],
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_seen_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ,
+  revoked_reason TEXT
+);
+
+CREATE INDEX idx_device_access_tokens_active_hash
+  ON device_access_tokens (token_hash)
+  WHERE revoked_at IS NULL;
+
+ALTER TABLE device_access_tokens ENABLE ROW LEVEL SECURITY;
+
+-- ============================================
 -- EXPENSES TABLE
 -- ============================================
 

--- a/types/database.ts
+++ b/types/database.ts
@@ -17,6 +17,7 @@ export type Database = {
           token_hash: string
           scopes: string[]
           created_at: string
+          expires_at: string | null
           last_seen_at: string | null
           revoked_at: string | null
           revoked_reason: string | null
@@ -28,6 +29,7 @@ export type Database = {
           token_hash: string
           scopes?: string[]
           created_at?: string
+          expires_at: string
           last_seen_at?: string | null
           revoked_at?: string | null
           revoked_reason?: string | null
@@ -35,6 +37,7 @@ export type Database = {
         Update: {
           label?: string
           scopes?: string[]
+          expires_at?: string
           last_seen_at?: string | null
           revoked_at?: string | null
           revoked_reason?: string | null

--- a/types/database.ts
+++ b/types/database.ts
@@ -9,6 +9,38 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
+      device_access_tokens: {
+        Row: {
+          id: string
+          user_id: string
+          label: string
+          token_hash: string
+          scopes: string[]
+          created_at: string
+          last_seen_at: string | null
+          revoked_at: string | null
+          revoked_reason: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          label: string
+          token_hash: string
+          scopes?: string[]
+          created_at?: string
+          last_seen_at?: string | null
+          revoked_at?: string | null
+          revoked_reason?: string | null
+        }
+        Update: {
+          label?: string
+          scopes?: string[]
+          last_seen_at?: string | null
+          revoked_at?: string | null
+          revoked_reason?: string | null
+        }
+        Relationships: []
+      }
       product_events: {
         Row: {
           id: string


### PR DESCRIPTION
## Qué agrega\n- Endpoint autenticado `GET /api/device/v1/snapshot` para la ESP32.\n- Token opaco, revocable y scope `dashboard:read`.\n- Snapshot canónico de Saldo Vivo, Disponible Real, tarjetas y ritmo same-day.\n- SQL aditivo para `device_access_tokens`.\n\n## Validación\n- `npm test` — 77 archivos / 502 tests.\n- `npx tsc --noEmit`.\n- ESLint focalizado.\n- `npm run build` con variables Supabase placeholder (compilación; no prueba de datos reales).\n\n## Pendiente antes de firmware\n- Aplicar SQL en Supabase.\n- Deploy Preview con las env reales de Gota.\n- Generar token dev y comparar payload real contra Dashboard.