### PR TITLE
fix(device): allow ESP32 snapshot token auth

### DIFF
--- a/lib/device-auth/device-route.test.ts
+++ b/lib/device-auth/device-route.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { isDeviceSnapshotPath } from '@/proxy'
+
+describe('isDeviceSnapshotPath', () => {
+  it('sólo permite el endpoint versionado de lectura del dispositivo', () => {
+    expect(isDeviceSnapshotPath('/api/device/v1/snapshot')).toBe(true)
+    expect(isDeviceSnapshotPath('/api/device/v1/other')).toBe(false)
+    expect(isDeviceSnapshotPath('/api/dashboard')).toBe(false)
+    expect(isDeviceSnapshotPath('/api/device/v2/snapshot')).toBe(false)
+  })
+})

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,14 @@ import { createServerClient } from '@supabase/ssr'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
+/**
+ * The ESP32 cannot carry a browser session. This exact read-only route has
+ * independent bearer-token auth in its route handler; no other API is public.
+ */
+export function isDeviceSnapshotPath(pathname: string): boolean {
+  return pathname === '/api/device/v1/snapshot'
+}
+
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname
   const isPublicPath =
@@ -53,6 +61,7 @@ export async function proxy(request: NextRequest) {
   if (
     !user &&
     !isPublicPath &&
+    !isDeviceSnapshotPath(pathname) &&
     !request.nextUrl.pathname.startsWith('/login') &&
     !request.nextUrl.pathname.startsWith('/auth/') &&
     !request.nextUrl.pathname.startsWith('/share-target')


### PR DESCRIPTION
## Cambio\nPermite exclusivamente `/api/device/v1/snapshot` sin sesión web en el proxy. La autorización se conserva en el handler mediante bearer token opaco, scope, revocación y expiración.\n\n## Validación\n- `npm test`: 79 archivos / 505 tests.\n- `npx tsc --noEmit`.\n- lint focalizado.\n- `npm run build` con env placeholder.\n\nLa migración `device_access_tokens` ya fue aplicada y verificada en Supabase.